### PR TITLE
feat: support custom device type for main device

### DIFF
--- a/demos/docker-compose/device/docker-compose.yaml
+++ b/demos/docker-compose/device/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - /tmp
     privileged: true
     environment:
+      - TEDGE_DEVICE_TYPE=${DEVICE_TYPE:-demo-device}
       - DEVICE_ID=${DEVICE_ID:-}
       - C8Y_BASEURL=${C8Y_BASEURL:-}
       - C8Y_USER=${C8Y_USER:-}

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
   child02:
     <<: *child-defaults
     environment:
+      - TEDGE_DEVICE_TYPE=${DEVICE_TYPE:-demo-device}
       - CONNECTOR_DEVICE_ID=child02
 
 volumes:


### PR DESCRIPTION
Support using a custom device type via the `DEVICE_TYPE` environment variable

Signed-off-by: Reuben Miller <reuben.d.miller@gmail.com>