### PR TITLE
Fix container plugin integration

### DIFF
--- a/images/common/bootstrap.sh
+++ b/images/common/bootstrap.sh
@@ -124,6 +124,7 @@ PREFIX=${PREFIX:-tedge_}
 REPO_CHANNEL=${REPO_CHANNEL:-main}
 C8Y_BASEURL=${C8Y_BASEURL:-}
 COMMUNITY_REPO=${COMMUNITY_REPO:-"community"}
+BOOTSTRAP_POSTINST_DIR="${BOOTSTRAP_POSTINST_DIR:-/etc/boostrap/post.d}"
 
 
 get_debian_arch() {
@@ -856,6 +857,18 @@ main() {
                 sudo systemctl start tedge-mapper-collectd
             fi
         fi
+    fi
+
+    # Run optional post bootstrap scripts
+    if [ -d "$BOOTSTRAP_POSTINST_DIR" ]; then
+        for script in "$BOOTSTRAP_POSTINST_DIR"/*.sh; do
+            if [ -x "$script" ]; then
+                echo "Running post bootstrap script: $script"
+                "$script"
+            else
+                echo "Found post bootstrap script but it is not executable: file=$script"
+            fi
+        done
     fi
 
     if [ "$BOOTSTRAP" = 1 ] || [ "$CONNECT" = 1 ]; then

--- a/images/common/config/bootstrap/post.d/10-start-services.sh
+++ b/images/common/config/bootstrap/post.d/10-start-services.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Enable services
+#
+
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    sleep 5
+    echo "Enabling/starting tedge-container-monitor"
+    systemctl enable tedge-container-monitor
+    systemctl start tedge-container-monitor
+fi

--- a/images/common/config/tedge-container-plugin.env
+++ b/images/common/config/tedge-container-plugin.env
@@ -1,0 +1,1 @@
+INTERVAL=60

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -14,6 +14,13 @@ install_container_management () {
     
     sudo apt-get update
     sudo apt-get install -y docker-ce-cli docker-compose-plugin tedge-container-plugin
+
+    # Disable services to prevent from starting too early
+    # before thin-edge has been registered
+    if command -v systemctl; then
+        echo "Disabling tedge-container-monitor"
+        systemctl disable tedge-container-monitor
+    fi
 }
 
 main() {

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -67,6 +67,9 @@ RUN systemctl enable device-registration-server.service
 COPY common/optional-installer.sh .
 RUN ./optional-installer.sh
 
+# Copy bootstrap script hooks
+COPY common/config/bootstrap /etc/boostrap
+
 COPY common/config/system.toml /etc/tedge/
 COPY common/config/tedge.toml /etc/tedge/
 COPY common/config/c8y-configuration-plugin.toml /etc/tedge/c8y/

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -70,6 +70,8 @@ RUN ./optional-installer.sh
 # Copy bootstrap script hooks
 COPY common/config/bootstrap /etc/boostrap
 
+COPY common/config/tedge-container-plugin.env /etc/tedge-container-plugin/env
+
 COPY common/config/system.toml /etc/tedge/
 COPY common/config/tedge.toml /etc/tedge/
 COPY common/config/c8y-configuration-plugin.toml /etc/tedge/c8y/


### PR DESCRIPTION
The `tedge-container-plugin` was causing a few issues by starting too early. This would result in services being registered as child devices by Cumulocity as measurements would be pushed before the service was created by thin-edge.io

* Support post bootstrap script hooks (used to disable the service after the device has been bootstrapped)
* Delay the starting of the tedge-container-monitor service until after bootstrapping

**Note**: There may still be an issue in some instances, however the `tedge-container-plugin` will be adjusted to fix the root cause.