### PR TITLE
Fix podman compatibility

### DIFF
--- a/demos/docker-compose/device/docker-compose.yaml
+++ b/demos/docker-compose/device/docker-compose.yaml
@@ -5,11 +5,7 @@ x-child-defaults: &child-defaults
   image: ghcr.io/thin-edge/tedge-demo-child:${VERSION:-latest}
   pull_policy: always
   restart: always
-  links:
-    - tedge:tedge
   networks:
-    - tedge
-  depends_on:
     - tedge
 
 # Services
@@ -20,7 +16,7 @@ services:
     volumes:
       - etc:/etc
       # Enable docker from docker - But then this container has elevated access to system resources!
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /var/run/docker.sock:${DOCKER_SOCKET:-/var/run/docker.sock}:rw
     restart: always
     tmpfs:
       - /run

--- a/env.template
+++ b/env.template
@@ -4,3 +4,6 @@ C8Y_USER=demo@thin-edge.com
 
 # Testing: Cumulocity IoT Integration
 C8Y_PASSWORD=""
+
+# Set docker socket if you are using podman, or if your docker socket is not located at /var/run/docker.sock
+#DOCKER_SOCKET=

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - etc:/etc
 
       # Enable docker from docker - But then this container has elevated access to system resources!
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /var/run/docker.sock:${DOCKER_SOCKET:-/var/run/docker.sock}:rw
 
     restart: always
     tmpfs:

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -6,11 +6,7 @@ x-child-defaults: &child-defaults
       context: "../child-device"
       dockerfile: child.dockerfile
   restart: always
-  links:
-    - tedge:tedge
   networks:
-    - tedge
-  depends_on:
     - tedge
 
 services:


### PR DESCRIPTION
Initial support for podman (though no instructions just yet), as support is still experimental.

* Remove usage of `links` as this is is deprecated/legacy compose syntax
* Remove unnecessary`depends_on` for child devices as child containers will dynamically wait for the main device to be ready
* Support customizing the docker socket via an `.env` file when starting the docker compose project (required for podman to work as the docker socket is not located as `/var/run/docker.sock` for podman