### PR TITLE
fix: resolve child connector MQTT reconnection bug

### DIFF
--- a/images/child-device/connector/app.py
+++ b/images/child-device/connector/app.py
@@ -25,8 +25,8 @@ class App:
     # pylint: disable=too-few-public-methods
     def run(self):
         """Main application loop"""
-        # pylint: disable=broad-exception-caught
-        _queue = queue.SimpleQueue()
+        # pylint: disable=broad-except
+        metrics_queue = queue.SimpleQueue()
         config = Config()
 
         file = os.getenv("CONNECTOR_SETTINGS", "./config/connector.ini")
@@ -43,7 +43,7 @@ class App:
                 client.subscribe()
 
                 metrics_thread = threading.Thread(
-                    target=collect_metrics, args=(client, _queue)
+                    target=collect_metrics, args=(client, metrics_queue), daemon=True
                 )
                 metrics_thread.start()
                 while True:
@@ -53,6 +53,8 @@ class App:
                 log.info("MQTT broker is not ready yet")
             except KeyboardInterrupt:
                 log.info("Exiting...")
+                if client:
+                    client.shutdown()
                 sys.exit(0)
             except Exception as ex:
                 log.info("Unexpected error. %s", ex)

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -65,7 +65,6 @@ class TedgeClient:
 
         def on_disconnect(_client: Client, _userdata: Any, result_code: int):
             log.info("Client was disconnected. result_code=%d", result_code)
-            client.loop_stop()
 
         # Don't use a clean session so no messages will go missing
         if self.mqtt is None:

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -196,7 +196,7 @@ class TedgeClient:
             worker.put(self.config, client, JSONMessage(message.topic, payload))
 
         self.mqtt.message_callback_add(topic, add_job)
-        self.mqtt.subscribe(topic)
+        self.mqtt.subscribe(topic, qos=2)
         self._workers.append(worker)
 
     def loop_forever(self):

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -93,6 +93,8 @@ class TedgeClient:
                 )
             client.on_connect = on_connect
             client.on_disconnect = on_disconnect
+            # Enable paho mqtt logs to help with any mqtt connection debugging
+            client.enable_logger(log)
             log.info(
                 "Trying to connect to the MQTT broker: host=%s:%s, client_id=%s",
                 self.config.tedge.host,

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -109,8 +109,7 @@ class TedgeClient:
             raise RuntimeError("Failed to connect successfully to MQTT broker")
 
     def bootstrap(self):
-        """Register extra services once the mqtt client is up
-        """
+        """Register extra services once the mqtt client is up"""
         configuration.bootstrap(self.config, self.mqtt)
 
     def register(self):
@@ -167,7 +166,10 @@ class TedgeClient:
 
         # Only register that the child device is ready now
         # Register health check and bootstrap other plugin settings
-        log.info("Publishing health endpoint. device=%s, service=connector", self.config.device_id)
+        log.info(
+            "Publishing health endpoint. device=%s, service=connector",
+            self.config.device_id,
+        )
         self.mqtt.publish(
             health_topic("connector", self.config.device_id),
             json.dumps({"status": "up"}),

--- a/images/child-device/connector/management/metrics.py
+++ b/images/child-device/connector/management/metrics.py
@@ -33,7 +33,7 @@ def collect_metrics(client: TedgeClient, settings: queue.SimpleQueue):
                 timeout = settings.get(timeout=timeout)
             except queue.Empty:
                 pass
-            log.info("Checking metrics")
+            log.debug("Checking metrics")
             disk_root_usage = psutil.disk_usage("/").percent
             cpu_usage = psutil.cpu_percent()
             client.mqtt.publish(

--- a/images/child-device/connector/management/metrics.py
+++ b/images/child-device/connector/management/metrics.py
@@ -26,7 +26,7 @@ def collect_metrics(client: TedgeClient, settings: queue.SimpleQueue):
     """
     timeout = 5
     while True:
-        # pylint: disable=broad-exception-caught
+        # pylint: disable=broad-except
         try:
             try:
                 # use a queue to limit how often the collection is run

--- a/justfile
+++ b/justfile
@@ -51,6 +51,14 @@ shell *args='bash':
 shell-child *args='bash':
     docker compose -f images/debian-systemd/docker-compose.yaml exec child01 {{args}}
 
+# Show logs of the main device
+logs *args='':
+    docker compose -f images/debian-systemd/docker-compose.yaml exec tedge journalctl -f -u "c8y-*" -u "tedge-*" {{args}}
+
+# Show child device logs
+logs-child child='child01' *args='':
+    docker compose -f images/debian-systemd/docker-compose.yaml logs {{child}} -f {{args}}
+
 # Install python virtual environment
 venv:
   [ -d .venv ] || python3 -m venv .venv

--- a/tests/main/operations.robot
+++ b/tests/main/operations.robot
@@ -17,12 +17,12 @@ Restart device
 
 Install software package
     ${operation}=    Cumulocity.Install Software    vim-tiny,latest::apt
-    Operation Should Be SUCCESSFUL    ${operation}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=90
     Cumulocity.Device Should Have Installed Software    vim-tiny
 
 Uninstall software package
     Skip    Missing Uninstall software keyword
-    ${operation}=    Cumulocity.Install Software    vim-tiny
+    ${operation}=    Cumulocity.Install Software    vim-tiny    timeout=90
     Operation Should Be SUCCESSFUL    ${operation}
 
 Execute shell command


### PR DESCRIPTION
Fixing handling of the child device MQTT connection which resulted in the child connector not reacting to messages sent via MQTT.

The following improvements were made:

* feat(child): enable paho mqtt client logging by default
* feat(child): subscribe to topics using qos 2
* fix(child): prevent log spamming when checking metrics
* chore(child): format/lint
* feat(child): clean shutdown of client and threads
* fix(child): don't stop mqtt loop on disconnect
* fix(test): increase install timeouts to cater for devices with less CPU resources allocated to it