### PR TITLE
feat(ssh): enable sshd service by default during bootstrapping

### DIFF
--- a/images/common/config/bootstrap/post.d/10-start-services.sh
+++ b/images/common/config/bootstrap/post.d/10-start-services.sh
@@ -5,9 +5,18 @@
 
 set -e
 
-if command -v systemctl >/dev/null 2>&1; then
-    sleep 5
-    echo "Enabling/starting tedge-container-monitor"
-    systemctl enable tedge-container-monitor
-    systemctl start tedge-container-monitor
-fi
+start_enable_service() {
+    name="$1"
+    if command -v systemctl >/dev/null 2>&1; then
+        echo "Enabling/starting $name"
+        sudo systemctl enable "$name"
+
+        if [ -d /run/systemd/system ]; then
+            sudo systemctl start "$name"
+        fi
+    fi
+}
+
+sleep 5
+start_enable_service "tedge-container-monitor"
+start_enable_service "ssh"


### PR DESCRIPTION
Enable sshd out of the box by enabling/starting the sshd service after bootstrapping.