### PR TITLE
fix(bootstrap): normalize c8y.url before displaying it to prevent invalid url links

### DIFF
--- a/images/common/bootstrap.sh
+++ b/images/common/bootstrap.sh
@@ -764,7 +764,8 @@ display_banner_c8y() {
     echo "tedge.version:   $(tedge --version 2>/dev/null | tail -1 | cut -d' ' -f2)"
     echo "device.id:       ${DEVICE_ID}"
     DEVICE_SEARCH=$(echo "$DEVICE_ID" | sed 's/-/*/g')
-    echo "Cumulocity IoT:  https://${C8Y_BASEURL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_SEARCH}*"
+    DISPLAY_URL=$(echo "$C8Y_BASEURL" | sed 's|^https?://||g')
+    echo "Cumulocity IoT:  https://${DISPLAY_URL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_SEARCH}*"
     echo ""
     echo "----------------------------------------------------------"    
 }


### PR DESCRIPTION
fix(bootstrap): normalize c8y.url before displaying it to prevent invalid url links