### PR TITLE
feat(telemetry): monitor tedge processes with collectd

### DIFF
--- a/images/common/config/collectd.conf.d/tedge-monitoring.conf
+++ b/images/common/config/collectd.conf.d/tedge-monitoring.conf
@@ -1,5 +1,5 @@
 <LoadPlugin processes>
-    Interval 10
+    Interval 60
 </LoadPlugin>
 
 <Plugin processes>

--- a/images/common/config/collectd.conf.d/tedge-monitoring.conf
+++ b/images/common/config/collectd.conf.d/tedge-monitoring.conf
@@ -1,0 +1,24 @@
+<LoadPlugin processes>
+    Interval 10
+</LoadPlugin>
+
+<Plugin processes>
+    CollectFileDescriptor true
+    CollectContextSwitch false
+    CollectMemoryMaps true
+
+    # Note: Use cumulocity instead of c8y in the names to prevent the devicemanagement UI from removing it
+    # as it automatically removes "c8y" from the string (as it often used as a common prefix in fragments)
+    ProcessMatch "mosquitto" "/usr/sbin/mosquitto.*"
+    ProcessMatch "tedge-mapper-cumulocity" "/usr/bin/tedge.mapper c8y"
+    ProcessMatch "tedge-mapper-aws" "/usr/bin/tedge.mapper aws"
+    ProcessMatch "tedge-mapper-az" "/usr/bin/tedge.mapper az"
+    ProcessMatch "tedge-mapper-collectd" "/usr/bin/tedge.mapper collectd"
+    ProcessMatch "tedge-agent" "/usr/bin/tedge.agent.*"
+    ProcessMatch "cumulocity-log-plugin" "/usr/bin/c8y.log.plugin.*"
+    ProcessMatch "cumulocity-firmware-plugin" "/usr/bin/c8y-firmware-plugin.*"
+    ProcessMatch "cumulocity-configuration-plugin" "/usr/bin/c8y.configuration.plugin.*"
+
+    # Group all tedge components together
+    ProcessMatch "tedge-all" "/usr/bin/(c8y-configuration-plugin|c8y-log-plugin|c8y-firmware-plugin|tedge-mapper|tedge-agent|tedge-device.*).*"
+</Plugin>

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -20,6 +20,8 @@ RUN apt-get -y update \
         mosquitto \
         mosquitto-clients \
         collectd-core \
+        # extra collectd shared libraries
+        libmnl0 \
         vim.tiny
 
 # Remove unnecessary systemd services
@@ -77,6 +79,8 @@ COPY common/config/tedge.toml /etc/tedge/
 COPY common/config/c8y-configuration-plugin.toml /etc/tedge/c8y/
 COPY common/config/c8y-log-plugin.toml /etc/tedge/c8y/
 COPY common/config/collectd.conf /etc/collectd/collectd.conf
+COPY common/config/collectd.conf.d /etc/collectd/collectd.conf.d
+
 # Custom mosquitto config
 COPY common/config/mosquitto.conf /etc/mosquitto/conf.d/
 

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -19,4 +19,4 @@ Service status
 
 Sends measurements
     ${date_from}=    Get Test Start Time
-    Cumulocity.Device Should Have Measurements    minimum=1    after=${date_from}    timeout=90
+    Cumulocity.Device Should Have Measurements    minimum=1    after=${date_from}    timeout=120


### PR DESCRIPTION
Add process metrics for individual tedge processes and mosquitto as well as a summation of all tedge components (called "tedge-all") to give an overview of all resources consumed by thin-edge.io.