### PR TITLE
fix: disable tedge-container-plugin metrics for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ The following features are covered by the demo.
     ```sh
     just shell systemctl restart tedge-mapper-c8y
     ```
+
+* telemetry data from the [tedge-container-plugin](https://github.com/thin-edge/tedge-container-plugin) is currently disabled due to an issue where the services would appear as child devices instead
+
+    Root cause: When measurements are sent to a service before a service has been registered with Cumulocity IoT.

--- a/images/common/config/tedge-container-plugin.env
+++ b/images/common/config/tedge-container-plugin.env
@@ -1,1 +1,4 @@
 INTERVAL=60
+
+# Telemetry data is currently disabled due to service sometimes being created as a child device
+TELEMETRY=0


### PR DESCRIPTION
This should avoid container services being added a child devices

This is a temporary measure until a logic can be added to wait for the service to be registered with the cloud.