### PR TITLE
fix: improve service description for the startup-notifier

### DIFF
--- a/images/common/utils/startup-notifier/startup-notifier.service
+++ b/images/common/utils/startup-notifier/startup-notifier.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=startup-startup
+Description=Send an event when the device starts up
 After=mosquitto.target
 
 [Service]


### PR DESCRIPTION
Add a more description description to the `startup-notifier` service.