### PR TITLE
fix(connector): escape dots in regex to avoid accidental matches

### DIFF
--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -25,7 +25,12 @@ def update_url(url: str, replace_url: str) -> str:
     Args:
         url (str): Url to be modified
     """
-    return re.sub(r"^(https?://)?(0\.0\.0\.0|127\.0\.\d+\.\d+|localhost)(:\d+)?", replace_url, url, 1)
+    return re.sub(
+        r"^(https?://)?(0\.0\.0\.0|127\.0\.\d+\.\d+|localhost)(:\d+)?",
+        replace_url,
+        url,
+        1,
+    )
 
 
 class TedgeClient:
@@ -90,6 +95,7 @@ class TedgeClient:
 
             def _create_on_connect_callback(done):
                 _done = done
+
                 def on_connect(_client, _userdata, _flags, result_code):
                     nonlocal _done
                     if result_code == 0:

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -19,12 +19,13 @@ log = logging.getLogger(__file__)
 
 def update_url(url: str, replace_url: str) -> str:
     """Modify the url by replacing any reference to a generic 0.0.0.0
-    ip with the real ip address of http server hosted by thin-edge.io
+    ip or a loopback address with the real ip address of http server
+    hosted by thin-edge.io
 
     Args:
         url (str): Url to be modified
     """
-    return re.sub(r"^(https?://)?0.0.0.0(:\d+)?", replace_url, url, 1)
+    return re.sub(r"^(https?://)?(0.0.0.0|127.0.\d+.\d+|localhost)(:\d+)?", replace_url, url, 1)
 
 
 class TedgeClient:

--- a/images/child-device/connector/client.py
+++ b/images/child-device/connector/client.py
@@ -25,7 +25,7 @@ def update_url(url: str, replace_url: str) -> str:
     Args:
         url (str): Url to be modified
     """
-    return re.sub(r"^(https?://)?(0.0.0.0|127.0.\d+.\d+|localhost)(:\d+)?", replace_url, url, 1)
+    return re.sub(r"^(https?://)?(0\.0\.0\.0|127\.0\.\d+\.\d+|localhost)(:\d+)?", replace_url, url, 1)
 
 
 class TedgeClient:


### PR DESCRIPTION
The following host names / ip addresses will also be replaced with the tedg endpoint:

* localhost
* 127.0.0.1