### PR TITLE
chore(s6-overlay): update mosquitto to 2.0.17

### DIFF
--- a/images/alpine-s6/mosquitto/mosquitto.dockerfile
+++ b/images/alpine-s6/mosquitto/mosquitto.dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:2.0.16
+FROM eclipse-mosquitto:2.0.17
 
 COPY mosquitto/mosquitto-entrypoint.sh /entrypoint.sh
 COPY mosquitto/mosquitto.conf /mosquitto/config/mosquitto.conf


### PR DESCRIPTION
Update the mosquitto version used in the alpine linux s6-overlay demo container.