### PR TITLE
chore(alpine-s6): remove tedge run lock files setting as tedge auto detects this now

### DIFF
--- a/images/alpine-s6/alpine-s6.dockerfile
+++ b/images/alpine-s6/alpine-s6.dockerfile
@@ -35,7 +35,6 @@ RUN curl -sSL thin-edge.io/install-services.sh | sh -s
 # https://github.com/thin-edge/thin-edge.io/issues/2096
 COPY fake-sudo /usr/bin/sudo
 
-ENV TEDGE_RUN_LOCK_FILES=false
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000
 


### PR DESCRIPTION
Remove setting which disabled the run lock files as tedge auto detects whether lock files should be created or not via [2190](https://github.com/thin-edge/thin-edge.io/pull/2190).