### PR TITLE
extend s6-overlay example with child devices using thin-edge.io components

### DIFF
--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -2,23 +2,10 @@ version: "3"
 
 # child device template
 x-child-defaults: &child-defaults
-  image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
+  build:
+    dockerfile: alpine-s6.dockerfile
+    context: "."
   restart: always
-  environment:
-    - TEDGE_MQTT_CLIENT_HOST=mosquitto
-    - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
-    #
-    # Enable/disable specific services
-    #
-    - SERVICE_TEDGE_AGENT=1
-    - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
-    - SERVICE_TEDGE_LOG_PLUGIN=1
-    - SERVICE_TEDGE_MAPPER_C8Y=0
-    - SERVICE_TEDGE_MAPPER_AZ=0
-    - SERVICE_TEDGE_MAPPER_AWS=0
-    - SERVICE_TEDGE_MAPPER_COLLECTD=0
-    - SERVICE_C8Y_FIRMWARE_PLUGIN=0
-    - SERVICE_MOSQUITTO=0
   tmpfs:
     - /tmp
   # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
@@ -28,6 +15,22 @@ x-child-defaults: &child-defaults
     - tedge
   depends_on:
     - mosquitto
+
+x-child-env: &child-env
+    TEDGE_MQTT_CLIENT_HOST: mosquitto
+    TEDGE_C8Y_URL: ${C8Y_DOMAIN:-}
+    #
+    # Enable/disable specific services
+    #
+    SERVICE_TEDGE_AGENT: 1
+    SERVICE_TEDGE_CONFIGURATION_PLUGIN: 1
+    SERVICE_TEDGE_LOG_PLUGIN: 1
+    SERVICE_TEDGE_MAPPER_C8Y: 0
+    SERVICE_TEDGE_MAPPER_AZ: 0
+    SERVICE_TEDGE_MAPPER_AWS: 0
+    SERVICE_TEDGE_MAPPER_COLLECTD: 0
+    SERVICE_C8Y_FIRMWARE_PLUGIN: 0
+    SERVICE_MOSQUITTO: 0
 
 services:
   mosquitto:
@@ -82,7 +85,8 @@ services:
   child01:
     <<: *child-defaults
     environment:
-      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
+      <<: *child-env
+      TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
 
 volumes:
   device-certs:

--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -1,4 +1,34 @@
 version: "3"
+
+# child device template
+x-child-defaults: &child-defaults
+  image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
+  restart: always
+  environment:
+    - TEDGE_MQTT_CLIENT_HOST=mosquitto
+    - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
+    #
+    # Enable/disable specific services
+    #
+    - SERVICE_TEDGE_AGENT=1
+    - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
+    - SERVICE_TEDGE_LOG_PLUGIN=1
+    - SERVICE_TEDGE_MAPPER_C8Y=0
+    - SERVICE_TEDGE_MAPPER_AZ=0
+    - SERVICE_TEDGE_MAPPER_AWS=0
+    - SERVICE_TEDGE_MAPPER_COLLECTD=0
+    - SERVICE_C8Y_FIRMWARE_PLUGIN=0
+    - SERVICE_MOSQUITTO=0
+  tmpfs:
+    - /tmp
+  # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  networks:
+    - tedge
+  depends_on:
+    - mosquitto
+
 services:
   mosquitto:
     image: ghcr.io/thin-edge/tedge-mosquitto:${VERSION:-latest}
@@ -23,6 +53,19 @@ services:
     environment:
       - TEDGE_MQTT_CLIENT_HOST=mosquitto
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
+      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/main//
+      #
+      # Enable/disable specific services
+      #
+      - SERVICE_TEDGE_AGENT=1
+      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
+      - SERVICE_TEDGE_LOG_PLUGIN=1
+      - SERVICE_TEDGE_MAPPER_C8Y=1
+      - SERVICE_TEDGE_MAPPER_AZ=0
+      - SERVICE_TEDGE_MAPPER_AWS=0
+      - SERVICE_TEDGE_MAPPER_COLLECTD=0
+      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
+      - SERVICE_MOSQUITTO=0
     volumes:
       - device-certs:/etc/tedge/device-certs
     tmpfs:
@@ -34,6 +77,12 @@ services:
       - tedge
     depends_on:
       - mosquitto
+
+  # child devices
+  child01:
+    <<: *child-defaults
+    environment:
+      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
 
 volumes:
   device-certs:

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,0 +1,41 @@
+# Advanced examples
+
+## Single process containers
+
+An additional single-process container are also provided to show how thin-edge.io can operate in a pure container environment.
+
+### Start
+
+1. Start up the alpine-s6 image
+
+    ```
+    just IMAGE=alpine-s6 up
+    ```
+
+    If you are having problems with the build then you can build without using any caching with the following command:
+
+    ```
+    just IMAGE=alpine-s6 up-no-cache
+    ```
+
+2. Bootstrap the device
+
+    ```
+    just IMAGE=alpine-s6 bootstrap
+    ```
+
+3. Follow the instructions printed on the console to go to your device in Cumulocity IoT
+
+### Stop
+
+The setup can be stopped by running the following command:
+
+```
+just IMAGE=alpine-s6 down
+```
+
+Or if you want to remove everything including the device certificate, then run the following command instead:
+
+```
+just IMAGE=alpine-s6 down-all
+```

--- a/images/alpine-s6/alpine-s6.dockerfile
+++ b/images/alpine-s6/alpine-s6.dockerfile
@@ -35,8 +35,17 @@ RUN curl -sSL thin-edge.io/install-services.sh | sh -s \
         c8y-command-plugin \
         tedge-apk-plugin
 
+# Set permissions of all files under /etc/tedge
+# TODO: Can thin-edge.io set permissions during installation?
+RUN chown -R tedge:tedge /etc/tedge
+
+# Custom init. scripts
+COPY cont-init.d/*  /etc/cont-init.d/
+
 # Add custom config
 COPY bootstrap.sh /usr/bin/
+COPY tedge-log-plugin.toml /etc/tedge/plugins/
+COPY tedge-configuration-plugin.toml /etc/tedge/plugins/
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000

--- a/images/alpine-s6/bootstrap.sh
+++ b/images/alpine-s6/bootstrap.sh
@@ -1,13 +1,44 @@
 #!/bin/sh
 set -e
 
-if [ -z "$C8Y_USER" ]; then
-    echo "C8Y_USER is not set"
-    exit 1
+SHOULD_PROMPT=${SHOULD_PROMPT:-1}
+CAN_PROMPT=0
+
+#
+# Detect if the shell is running in interactive mode or not
+if [ -t 0 ]; then
+    CAN_PROMPT=1
+else
+    CAN_PROMPT=0
 fi
 
-if [ -n "$C8Y_PASSWORD" ]; then
-    C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
-else
-     tedge cert upload c8y --user "$C8Y_USER"
+prompt_value() {
+    user_text="$1"
+    value="$2"
+
+    if [ "$SHOULD_PROMPT" = 1 ] && [ "$CAN_PROMPT" = 1 ]; then
+        printf "\n%s (%s): " "$user_text" "${value:-not set}" >&2
+        read -r user_input
+        if [ -n "$user_input" ]; then
+            value="$user_input"
+        fi
+    fi
+    echo "$value"
+}
+
+if [ -z "$TEDGE_MQTT_DEVICE_TOPIC_ID" ]; then
+    if [ -z "$C8Y_USER" ]; then
+        C8Y_USER=$(prompt_value "Enter your Cumulocity IoT user" "$C8Y_USER")
+    fi
+
+    if [ -z "$C8Y_USER" ]; then
+        echo "C8Y_USER is not set"
+        exit 1
+    fi
+
+    if [ -n "$C8Y_PASSWORD" ]; then
+        C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
+    else
+        tedge cert upload c8y --user "$C8Y_USER"
+    fi
 fi

--- a/images/alpine-s6/cont-init.d/configure.sh
+++ b/images/alpine-s6/cont-init.d/configure.sh
@@ -14,14 +14,16 @@ TOPIC_ID=$(tedge config get mqtt.device_topic_id)
 
 # FIXME: Remove once https://github.com/thin-edge/thin-edge.io/issues/2389 is resolved
 # A manual registration before the service starts up seems to prevent duplicate registration messages
-case "$TOPIC_ID" in
-    device/main//)
-        ;;
-    *)
-        echo "manually registering child-device" >&2
-        name=$(echo "$TOPIC_ID" | cut -d/ -f2)
-        body=$(printf '{"@type":"child-device","name":"%s"}' "$name")
-        tedge mqtt pub -r "$TOPIC_ROOT/$TOPIC_ID" "$body"
-        sleep 1
-        ;;
-esac
+if [ "$REGISTER_DEVICE" = 1 ]; then
+    case "$TOPIC_ID" in
+        device/main//)
+            ;;
+        *)
+            echo "manually registering child-device" >&2
+            name=$(echo "$TOPIC_ID" | cut -d/ -f2)
+            body=$(printf '{"@type":"child-device","name":"%s"}' "$name")
+            tedge mqtt pub -r "$TOPIC_ROOT/$TOPIC_ID" "$body"
+            sleep 1
+            ;;
+    esac
+fi

--- a/images/alpine-s6/cont-init.d/configure.sh
+++ b/images/alpine-s6/cont-init.d/configure.sh
@@ -1,0 +1,9 @@
+#!/command/with-contenv sh
+set -e
+
+# TODO: thin-edge.io does not support using a given hostname instead of an ip address
+EXTERNAL_ID="$(grep "$HOSTNAME" /etc/hosts | cut -f1)"
+if [ -n "$EXTERNAL_ID" ]; then
+    tedge config set http.bind.address "$EXTERNAL_ID"
+    tedge config set c8y.proxy.bind.address "$EXTERNAL_ID"
+fi

--- a/images/alpine-s6/cont-init.d/configure.sh
+++ b/images/alpine-s6/cont-init.d/configure.sh
@@ -7,3 +7,21 @@ if [ -n "$EXTERNAL_ID" ]; then
     tedge config set http.bind.address "$EXTERNAL_ID"
     tedge config set c8y.proxy.bind.address "$EXTERNAL_ID"
 fi
+
+# register device
+TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+
+# FIXME: Remove once https://github.com/thin-edge/thin-edge.io/issues/2389 is resolved
+# A manual registration before the service starts up seems to prevent duplicate registration messages
+case "$TOPIC_ID" in
+    device/main//)
+        ;;
+    *)
+        echo "manually registering child-device" >&2
+        name=$(echo "$TOPIC_ID" | cut -d/ -f2)
+        body=$(printf '{"@type":"child-device","name":"%s"}' "$name")
+        tedge mqtt pub -r "$TOPIC_ROOT/$TOPIC_ID" "$body"
+        sleep 1
+        ;;
+esac

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -25,8 +25,52 @@ services:
     environment:
       - TEDGE_MQTT_CLIENT_HOST=mosquitto
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
+      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/main//
+      #
+      # Enable/disable specific services
+      #
+      - SERVICE_TEDGE_AGENT=1
+      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
+      - SERVICE_TEDGE_LOG_PLUGIN=1
+      - SERVICE_TEDGE_MAPPER_C8Y=1
+      - SERVICE_TEDGE_MAPPER_AZ=0
+      - SERVICE_TEDGE_MAPPER_AWS=0
+      - SERVICE_TEDGE_MAPPER_COLLECTD=0
+      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
+      - SERVICE_MOSQUITTO=0
     volumes:
       - device-certs:/etc/tedge/device-certs
+    tmpfs:
+      - /tmp
+    # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - tedge
+    depends_on:
+      - mosquitto
+
+  child01:
+    build:
+      dockerfile: alpine-s6.dockerfile
+      context: "."
+    restart: always
+    environment:
+      - TEDGE_MQTT_CLIENT_HOST=mosquitto
+      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
+      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
+      #
+      # Enable/disable specific services
+      #
+      - SERVICE_TEDGE_AGENT=1
+      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
+      - SERVICE_TEDGE_LOG_PLUGIN=1
+      - SERVICE_TEDGE_MAPPER_C8Y=0
+      - SERVICE_TEDGE_MAPPER_AZ=0
+      - SERVICE_TEDGE_MAPPER_AWS=0
+      - SERVICE_TEDGE_MAPPER_COLLECTD=0
+      - SERVICE_C8Y_FIRMWARE_PLUGIN=0
+      - SERVICE_MOSQUITTO=0
     tmpfs:
       - /tmp
     # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -6,21 +6,6 @@ x-child-defaults: &child-defaults
     dockerfile: alpine-s6.dockerfile
     context: "."
   restart: always
-  environment:
-    - TEDGE_MQTT_CLIENT_HOST=mosquitto
-    - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
-    #
-    # Enable/disable specific services
-    #
-    - SERVICE_TEDGE_AGENT=1
-    - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
-    - SERVICE_TEDGE_LOG_PLUGIN=1
-    - SERVICE_TEDGE_MAPPER_C8Y=0
-    - SERVICE_TEDGE_MAPPER_AZ=0
-    - SERVICE_TEDGE_MAPPER_AWS=0
-    - SERVICE_TEDGE_MAPPER_COLLECTD=0
-    - SERVICE_C8Y_FIRMWARE_PLUGIN=0
-    - SERVICE_MOSQUITTO=0
   tmpfs:
     - /tmp
   # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
@@ -30,6 +15,22 @@ x-child-defaults: &child-defaults
     - tedge
   depends_on:
     - mosquitto
+
+x-child-env: &child-env
+    TEDGE_MQTT_CLIENT_HOST: mosquitto
+    TEDGE_C8Y_URL: ${C8Y_DOMAIN:-}
+    #
+    # Enable/disable specific services
+    #
+    SERVICE_TEDGE_AGENT: 1
+    SERVICE_TEDGE_CONFIGURATION_PLUGIN: 1
+    SERVICE_TEDGE_LOG_PLUGIN: 1
+    SERVICE_TEDGE_MAPPER_C8Y: 0
+    SERVICE_TEDGE_MAPPER_AZ: 0
+    SERVICE_TEDGE_MAPPER_AWS: 0
+    SERVICE_TEDGE_MAPPER_COLLECTD: 0
+    SERVICE_C8Y_FIRMWARE_PLUGIN: 0
+    SERVICE_MOSQUITTO: 0
 
 services:
   mosquitto:
@@ -86,7 +87,8 @@ services:
   child01:
     <<: *child-defaults
     environment:
-      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
+      <<: *child-env
+      TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
 
 volumes:
   device-certs:

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -1,4 +1,36 @@
 version: "3"
+
+# child device template
+x-child-defaults: &child-defaults
+  build:
+    dockerfile: alpine-s6.dockerfile
+    context: "."
+  restart: always
+  environment:
+    - TEDGE_MQTT_CLIENT_HOST=mosquitto
+    - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
+    #
+    # Enable/disable specific services
+    #
+    - SERVICE_TEDGE_AGENT=1
+    - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
+    - SERVICE_TEDGE_LOG_PLUGIN=1
+    - SERVICE_TEDGE_MAPPER_C8Y=0
+    - SERVICE_TEDGE_MAPPER_AZ=0
+    - SERVICE_TEDGE_MAPPER_AWS=0
+    - SERVICE_TEDGE_MAPPER_COLLECTD=0
+    - SERVICE_C8Y_FIRMWARE_PLUGIN=0
+    - SERVICE_MOSQUITTO=0
+  tmpfs:
+    - /tmp
+  # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  networks:
+    - tedge
+  depends_on:
+    - mosquitto
+
 services:
   mosquitto:
     build:
@@ -50,36 +82,11 @@ services:
     depends_on:
       - mosquitto
 
+  # child devices
   child01:
-    build:
-      dockerfile: alpine-s6.dockerfile
-      context: "."
-    restart: always
+    <<: *child-defaults
     environment:
-      - TEDGE_MQTT_CLIENT_HOST=mosquitto
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
       - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
-      #
-      # Enable/disable specific services
-      #
-      - SERVICE_TEDGE_AGENT=1
-      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
-      - SERVICE_TEDGE_LOG_PLUGIN=1
-      - SERVICE_TEDGE_MAPPER_C8Y=0
-      - SERVICE_TEDGE_MAPPER_AZ=0
-      - SERVICE_TEDGE_MAPPER_AWS=0
-      - SERVICE_TEDGE_MAPPER_COLLECTD=0
-      - SERVICE_C8Y_FIRMWARE_PLUGIN=0
-      - SERVICE_MOSQUITTO=0
-    tmpfs:
-      - /tmp
-    # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - tedge
-    depends_on:
-      - mosquitto
 
 volumes:
   device-certs:

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -22,6 +22,7 @@ x-child-env: &child-env
     #
     # Enable/disable specific services
     #
+    REGISTER_DEVICE: 1
     SERVICE_TEDGE_AGENT: 1
     SERVICE_TEDGE_CONFIGURATION_PLUGIN: 1
     SERVICE_TEDGE_LOG_PLUGIN: 1

--- a/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
+++ b/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
@@ -32,10 +32,7 @@ tedge disconnect c8y 2>&1 ||:
 while true; do
     echo "Registering device"
 
-    # TODO: update to use the exit code, once ticket is resolved:
-    # https://github.com/thin-edge/thin-edge.io/issues/2172
-    resp=$(tedge connect c8y 2>&1 ||:)
-    if echo "$resp" | grep -q "Saving configuration for requested bridge"; then
+    if tedge connect c8y; then
         break
     fi
     sleep 10

--- a/images/alpine-s6/mosquitto/mosquitto.dockerfile
+++ b/images/alpine-s6/mosquitto/mosquitto.dockerfile
@@ -1,12 +1,10 @@
-FROM eclipse-mosquitto:2.0.17
+FROM eclipse-mosquitto:2.0.18
 
 COPY mosquitto/mosquitto-entrypoint.sh /entrypoint.sh
 COPY mosquitto/mosquitto.conf /mosquitto/config/mosquitto.conf
 
-# Install thin-edge.io, but only keep tedge cli as it is used
-# to setup mosquitto
-RUN wget -O - thin-edge.io/install.sh | sh -s -- -p tarball \
-    && rm -f /usr/bin/tedge-* /usr/bin/c8y-*
+# Install thin-edge.io, use tedge cli to setup mosquitto
+RUN wget -O - thin-edge.io/install.sh | sh -s
 
 ENV TEDGE_MQTT_BIND_ADDRESS=0.0.0.0
 ENV TEDGE_MQTT_BIND_PORT=1883

--- a/images/alpine-s6/tedge-configuration-plugin.toml
+++ b/images/alpine-s6/tedge-configuration-plugin.toml
@@ -1,0 +1,4 @@
+files = [
+    { path = '/etc/tedge/tedge.toml', type = 'tedge.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+]

--- a/images/alpine-s6/tedge-log-plugin.toml
+++ b/images/alpine-s6/tedge-log-plugin.toml
@@ -1,0 +1,4 @@
+files = [
+    { type = "software-management", path = "/var/log/tedge/agent/software-*" },
+    { type = "shell", path = "/var/log/tedge/agent/c8y_Command-*" },
+]

--- a/tests/alpine-s6/children/operations.robot
+++ b/tests/alpine-s6/children/operations.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Resource    ../../resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary
+
+Suite Setup    Set Child Device1
+
+*** Test Cases ***
+
+It Should Show Supported Log File Types
+    Cumulocity.Should Have Services    name=tedge-log-plugin    status=up
+    Cumulocity.Should Support Log File Types    software-management    shell
+
+Get Log File
+    ${operation}=     Cumulocity.Get Log File    type=software-management
+    Operation Should Be SUCCESSFUL    ${operation}
+
+Set Configuration
+    [Teardown]    Revert Configuration
+    ${binary_url}=    Cumulocity.Create Inventory Binary    tedge-configuration-plugin-2.toml    tedge-configuration-plugin    file=${CURDIR}/tedge-configuration-plugin-2.toml
+    ${operation}=    Cumulocity.Set Configuration    typename=tedge-configuration-plugin    url=${binary_url}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Support Configurations    tedge-configuration-plugin    tedge.toml    system.toml    tedge-log-plugin.toml
+
+Get Configuration
+    ${operation}=    Cumulocity.Get Configuration    typename=tedge.toml
+    Operation Should Be SUCCESSFUL    ${operation}
+
+*** Keywords ***
+
+Revert Configuration
+    ${binary_url}=    Cumulocity.Create Inventory Binary    tedge-configuration-plugin-1.toml    tedge-configuration-plugin    file=${CURDIR}/tedge-configuration-plugin-1.toml
+    ${operation}=    Cumulocity.Set Configuration    typename=tedge-configuration-plugin    url=${binary_url}
+    Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/alpine-s6/children/tedge-configuration-plugin-1.toml
+++ b/tests/alpine-s6/children/tedge-configuration-plugin-1.toml
@@ -1,0 +1,4 @@
+files = [
+    { path = '/etc/tedge/tedge.toml', type = 'tedge.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+]

--- a/tests/alpine-s6/children/tedge-configuration-plugin-2.toml
+++ b/tests/alpine-s6/children/tedge-configuration-plugin-2.toml
@@ -1,0 +1,5 @@
+files = [
+    { path = '/etc/tedge/tedge.toml', type = 'tedge.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/plugins/tedge-log-plugin.toml', type = 'tedge-log-plugin.toml', user = 'tedge', group = 'tedge', mode = 0o644 },
+]

--- a/tests/alpine-s6/children/telemetry.robot
+++ b/tests/alpine-s6/children/telemetry.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Resource    ../../resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary
+
+Suite Setup    Set Child Device1
+
+*** Test Cases ***
+
+Service status
+    Cumulocity.Should Have Services    name=tedge-agent    service_type=service    status=up
+    Cumulocity.Should Have Services    name=tedge-configuration-plugin    service_type=service    status=up
+    Cumulocity.Should Have Services    name=tedge-log-plugin    service_type=service    status=up

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.16.0
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.3.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.24.2
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.10.2


### PR DESCRIPTION
Add a child device in the `s6-overlay` example using the same container image but turning some services off.