### PR TITLE
run tedge-mapper-c8y in an independent container

### DIFF
--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -1,10 +1,8 @@
 version: "3"
 
 # child device template
-x-child-defaults: &child-defaults
-  build:
-    dockerfile: alpine-s6.dockerfile
-    context: "."
+x-device-defaults: &device-defaults
+  image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
   restart: always
   tmpfs:
     - /tmp
@@ -16,12 +14,12 @@ x-child-defaults: &child-defaults
   depends_on:
     - mosquitto
 
-x-child-env: &child-env
+x-device-env: &device-env
     TEDGE_MQTT_CLIENT_HOST: mosquitto
-    TEDGE_C8Y_URL: ${C8Y_DOMAIN:-}
     #
     # Enable/disable specific services
     #
+    REGISTER_DEVICE: 1
     SERVICE_TEDGE_AGENT: 1
     SERVICE_TEDGE_CONFIGURATION_PLUGIN: 1
     SERVICE_TEDGE_LOG_PLUGIN: 1
@@ -35,7 +33,6 @@ x-child-env: &child-env
 services:
   mosquitto:
     image: ghcr.io/thin-edge/tedge-mosquitto:${VERSION:-latest}
-    pull_policy: always
     restart: always
     environment:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
@@ -49,28 +46,32 @@ services:
     networks:
       - tedge
 
-  tedge:
+  tedge-mapper-c8y:
     image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
-    pull_policy: always
     restart: always
     environment:
       - TEDGE_MQTT_CLIENT_HOST=mosquitto
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
-      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/main//
       #
       # Enable/disable specific services
       #
-      - SERVICE_TEDGE_AGENT=1
-      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
-      - SERVICE_TEDGE_LOG_PLUGIN=1
+      # Rename when https://github.com/thin-edge/thin-edge.io/issues/2391 is resolved
+      - FIXME_TEDGE_HTTP_CLIENT_HOST=tedge
       - SERVICE_TEDGE_MAPPER_C8Y=1
+      # FIXME: remove once c8y-firmware-plugin has been made generic
+      # Run c8y-firmware-plugin on the mapper as it needs access to the certificates and c8y.url
+      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
+      - SERVICE_TEDGE_AGENT=0
+      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=0
+      - SERVICE_TEDGE_LOG_PLUGIN=0
       - SERVICE_TEDGE_MAPPER_AZ=0
       - SERVICE_TEDGE_MAPPER_AWS=0
       - SERVICE_TEDGE_MAPPER_COLLECTD=0
-      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
       - SERVICE_MOSQUITTO=0
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
+      - file-transfer:/var/tedge
     tmpfs:
       - /tmp
     # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
@@ -81,16 +82,31 @@ services:
     depends_on:
       - mosquitto
 
+  # main device
+  tedge:
+    <<: *device-defaults
+    environment:
+      <<: *device-env
+      TEDGE_MQTT_DEVICE_TOPIC_ID: device/main//
+      # FIXME: Move environment variable to dockerfile once https://github.com/thin-edge/thin-edge.io/issues/2391 is resolved
+      # as the bind and client host addresses will be decoupled
+      TEDGE_HTTP_BIND_ADDRESS: "0.0.0.0"
+
+    # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
+    volumes:
+      - file-transfer:/var/tedge
+
   # child devices
   child01:
-    <<: *child-defaults
+    <<: *device-defaults
     environment:
-      <<: *child-env
+      <<: *device-env
       TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
 
 volumes:
   device-certs:
   mosquitto:
+  file-transfer:
 
 networks:
   tedge:

--- a/images/alpine-s6/alpine-s6.dockerfile
+++ b/images/alpine-s6/alpine-s6.dockerfile
@@ -50,5 +50,7 @@ COPY tedge-configuration-plugin.toml /etc/tedge/plugins/
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000
 
+ENV TEDGE_C8Y_PROXY_BIND_ADDRESS 0.0.0.0
+
 USER "tedge"
 ENTRYPOINT ["/init"]

--- a/images/alpine-s6/cont-init.d/configure.sh
+++ b/images/alpine-s6/cont-init.d/configure.sh
@@ -1,22 +1,30 @@
 #!/command/with-contenv sh
 set -e
 
-# TODO: thin-edge.io does not support using a given hostname instead of an ip address
-EXTERNAL_ID="$(grep "$HOSTNAME" /etc/hosts | cut -f1)"
-if [ -n "$EXTERNAL_ID" ]; then
-    tedge config set http.bind.address "$EXTERNAL_ID"
-    tedge config set c8y.proxy.bind.address "$EXTERNAL_ID"
-fi
+# FIXME: Remove when https://github.com/thin-edge/thin-edge.io/issues/2391 is resolved
+# In the future the the bind and client host will be decoupled and the http.client.host will
+# accept hostnames (removing the need to lookup the ip address)
+if [ -n "$FIXME_TEDGE_HTTP_CLIENT_HOST" ]; then
+    #
+    # Configure mapper to point to correct ip address of tedge-agent http server
+    #
+    FIXME_TEDGE_HTTP_CLIENT_HOST_IP=$(getent hosts "$FIXME_TEDGE_HTTP_CLIENT_HOST" | cut -d' ' -f1)
 
-# register device
-TOPIC_ROOT=$(tedge config get mqtt.topic_root)
-TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+    if [ -n "$FIXME_TEDGE_HTTP_CLIENT_HOST_IP" ]; then
+        echo "Setting http.bind.address address to $FIXME_TEDGE_HTTP_CLIENT_HOST_IP ($FIXME_TEDGE_HTTP_CLIENT_HOST)" >&2
+        tedge config set http.bind.address "$FIXME_TEDGE_HTTP_CLIENT_HOST_IP"
+    fi
+fi
 
 # FIXME: Remove once https://github.com/thin-edge/thin-edge.io/issues/2389 is resolved
 # A manual registration before the service starts up seems to prevent duplicate registration messages
+TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+
 if [ "$REGISTER_DEVICE" = 1 ]; then
     case "$TOPIC_ID" in
         device/main//)
+            # Don't register when it is the main device
             ;;
         *)
             echo "manually registering child-device" >&2

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
 # child device template
-x-child-defaults: &child-defaults
+x-device-defaults: &device-defaults
   build:
     dockerfile: alpine-s6.dockerfile
     context: "."
@@ -16,9 +16,8 @@ x-child-defaults: &child-defaults
   depends_on:
     - mosquitto
 
-x-child-env: &child-env
+x-device-env: &device-env
     TEDGE_MQTT_CLIENT_HOST: mosquitto
-    TEDGE_C8Y_URL: ${C8Y_DOMAIN:-}
     #
     # Enable/disable specific services
     #
@@ -51,7 +50,7 @@ services:
     networks:
       - tedge
 
-  tedge:
+  tedge-mapper-c8y:
     build:
       dockerfile: alpine-s6.dockerfile
       context: "."
@@ -59,21 +58,26 @@ services:
     environment:
       - TEDGE_MQTT_CLIENT_HOST=mosquitto
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
-      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/main//
       #
       # Enable/disable specific services
       #
-      - SERVICE_TEDGE_AGENT=1
-      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=1
-      - SERVICE_TEDGE_LOG_PLUGIN=1
+      # Rename when https://github.com/thin-edge/thin-edge.io/issues/2391 is resolved
+      - FIXME_TEDGE_HTTP_CLIENT_HOST=tedge
       - SERVICE_TEDGE_MAPPER_C8Y=1
+      # FIXME: remove once c8y-firmware-plugin has been made generic
+      # Run c8y-firmware-plugin on the mapper as it needs access to the certificates and c8y.url
+      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
+      - SERVICE_TEDGE_AGENT=0
+      - SERVICE_TEDGE_CONFIGURATION_PLUGIN=0
+      - SERVICE_TEDGE_LOG_PLUGIN=0
       - SERVICE_TEDGE_MAPPER_AZ=0
       - SERVICE_TEDGE_MAPPER_AWS=0
       - SERVICE_TEDGE_MAPPER_COLLECTD=0
-      - SERVICE_C8Y_FIRMWARE_PLUGIN=1
       - SERVICE_MOSQUITTO=0
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
+      - file-transfer:/var/tedge
     tmpfs:
       - /tmp
     # Support reaching other services from the host, e.g. curl http://host.docker.internal:8888
@@ -84,16 +88,31 @@ services:
     depends_on:
       - mosquitto
 
+  # main device
+  tedge:
+    <<: *device-defaults
+    environment:
+      <<: *device-env
+      TEDGE_MQTT_DEVICE_TOPIC_ID: device/main//
+      # FIXME: Move environment variable to dockerfile once https://github.com/thin-edge/thin-edge.io/issues/2391 is resolved
+      # as the bind and client host addresses will be decoupled
+      TEDGE_HTTP_BIND_ADDRESS: "0.0.0.0"
+
+    # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
+    volumes:
+      - file-transfer:/var/tedge
+
   # child devices
   child01:
-    <<: *child-defaults
+    <<: *device-defaults
     environment:
-      <<: *child-env
+      <<: *device-env
       TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
 
 volumes:
   device-certs:
   mosquitto:
+  file-transfer:
 
 networks:
   tedge:

--- a/tests/alpine-s6/children/operations.robot
+++ b/tests/alpine-s6/children/operations.robot
@@ -23,7 +23,7 @@ Set Configuration
     Cumulocity.Should Support Configurations    tedge-configuration-plugin    tedge.toml    system.toml    tedge-log-plugin.toml
 
 Get Configuration
-    ${operation}=    Cumulocity.Get Configuration    typename=tedge.toml
+    ${operation}=    Cumulocity.Get Configuration    typename=tedge-configuration-plugin
     Operation Should Be SUCCESSFUL    ${operation}
 
 *** Keywords ***


### PR DESCRIPTION
Move the tedge-mapper-c8y into an independent container.

There are a few "workarounds" required to make this happen, however thin-edge.io tickets have been created so that when they are resolved, the setup can be simplified even further.

* c8y-firmware-plugin still needs to be run along side the tedge-mapper-c8y as it needs access to the tedge certificate still.
* http.bind.address needs to be manually set on startup. https://github.com/thin-edge/thin-edge.io/issues/2391
* child device needs to be registered manually on startup. https://github.com/thin-edge/thin-edge.io/issues/2389
* tedge-mapper-c8y still needs access to the /var/tedge folder used by the tedge-agent. https://github.com/thin-edge/thin-edge.io/issues/2390