### PR TITLE
Refactoring single process container image demo

### DIFF
--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 # child device template
 x-device-defaults: &device-defaults
-  image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
+  image: ghcr.io/thin-edge/tedge-demo-s6:${VERSION:-latest}
   restart: always
   tmpfs:
     - /tmp
@@ -46,7 +46,7 @@ services:
       - tedge
 
   tedge-mapper-c8y:
-    image: ghcr.io/thin-edge/tedge-demo-main-s6:${VERSION:-latest}
+    image: ghcr.io/thin-edge/tedge-demo-s6:${VERSION:-latest}
     restart: always
     environment:
       - TEDGE_MQTT_CLIENT_HOST=mosquitto

--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -38,7 +38,6 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
       - C8Y_USER=${C8Y_USER:-}
       - C8Y_PASSWORD=${C8Y_PASSWORD:-}
-      - C8Y_MQTT_PORT=${C8Y_MQTT_PORT:-8883}
       - DEVICE_ID=${DEVICE_ID:-}
     volumes:
       - device-certs:/etc/tedge/device-certs

--- a/demos/docker-compose/alpine-s6/docker-compose.yaml
+++ b/demos/docker-compose/alpine-s6/docker-compose.yaml
@@ -94,6 +94,8 @@ services:
     # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
     volumes:
       - file-transfer:/var/tedge
+    # Use root user if you want to be able to add/remove apk packages inside the container
+    # user: root
 
   # child devices
   child01:
@@ -101,6 +103,8 @@ services:
     environment:
       <<: *device-env
       TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
+    # Use root user if you want to be able to add/remove apk packages inside the container
+    # user: root
 
 volumes:
   device-certs:

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -4,6 +4,46 @@
 
 An additional single-process container are also provided to show how thin-edge.io can operate in a pure container environment.
 
+It must be noted that running in a container has a different purpose than the systemd example as single process containers are meant to be more restrictive and in general "read-only". Therefore some of the features offered by the systemd demo are not applicable for the single process container as they true to solve different use-cases.
+
+The following features are covered by the demo.
+
+**main/child device**
+
+* [x] Configuration management
+* [x] Device reboot
+* [ ] Events
+    * [ ] On boot-up service: sends an event on startup
+* [x] Log management
+    * [x] log files
+* [ ] Measurements
+* [ ] Remote Access
+    * [ ] SSH
+* [x] Services
+    * [x] tedge services
+* [x] Shell
+* [x] Software management
+    * [x] apk (Only supports software list unless if the container is run as "root")
+    * [ ] container (docker, docker-compose)
+
+**Child devices**
+
+* [x] Configuration management
+* [x] Device reboot
+* [ ] Events
+    * [ ] On boot-up service: sends an event on startup
+* [x] Log management
+    * [x] log files
+* [ ] Measurements
+* [ ] Remote Access
+    * [ ] SSH
+* [x] Services
+    * [x] tedge services
+* [ ] Shell
+* [x] Software management
+    * [x] apk (Only supports software list unless if the container is run as "root")
+    * [ ] container (docker, docker-compose)
+
 ### Start
 
 1. Start up the alpine-s6 image

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -42,7 +42,6 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
       - C8Y_USER=${C8Y_USER:-}
       - C8Y_PASSWORD=${C8Y_PASSWORD:-}
-      - C8Y_MQTT_PORT=${C8Y_MQTT_PORT:-8883}
       - DEVICE_ID=${DEVICE_ID:-}
     volumes:
       - device-certs:/etc/tedge/device-certs

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -100,6 +100,7 @@ services:
     # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
     volumes:
       - file-transfer:/var/tedge
+    user: root
 
   # child devices
   child01:
@@ -107,6 +108,7 @@ services:
     environment:
       <<: *device-env
       TEDGE_MQTT_DEVICE_TOPIC_ID: device/child01//
+    user: root
 
 volumes:
   device-certs:

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -86,6 +86,9 @@ services:
       - tedge
     depends_on:
       - mosquitto
+    # FIXME: Remove volume once https://github.com/thin-edge/thin-edge.io/issues/2390 is resolved
+    # However this is only required if the tedge container is running under the root user
+    user: root
 
   # main device
   tedge:

--- a/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
+++ b/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
@@ -6,10 +6,14 @@ C8Y_MQTT_PORT=${C8Y_MQTT_PORT:-8883}
 DEVICE_ID="${DEVICE_ID:-}"
 CREATE_CERT=${CREATE_CERT:-1}
 
+if ! command -V tedge >/dev/null 2>&1; then
+    echo "missing dependency: tedge must be installed!" >&2
+    exit 1
+fi
+
 #
 # Create device certificate
 if [ "$CREATE_CERT" = "1" ]; then
-    if command -V tedge >/dev/null 2>&1; then
         if [ -n "$DEVICE_ID" ]; then
         PRIVATE_CERT=$(tedge config get device.key_path)
         if [ ! -f "$PRIVATE_CERT" ]; then

--- a/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
+++ b/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-TEDGE_C8Y_URL="${TEDGE_C8Y_URL:-}"
-C8Y_MQTT_PORT=${C8Y_MQTT_PORT:-8883}
 DEVICE_ID="${DEVICE_ID:-}"
 CREATE_CERT=${CREATE_CERT:-1}
 
@@ -14,10 +12,10 @@ fi
 #
 # Create device certificate
 if [ "$CREATE_CERT" = "1" ]; then
-        if [ -n "$DEVICE_ID" ]; then
+    if [ -n "$DEVICE_ID" ]; then
         PRIVATE_CERT=$(tedge config get device.key_path)
         if [ ! -f "$PRIVATE_CERT" ]; then
-                tedge cert create --device-id "$DEVICE_ID"
+            tedge cert create --device-id "$DEVICE_ID"
         fi
     fi
 fi

--- a/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
+++ b/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
@@ -11,9 +11,9 @@ CREATE_CERT=${CREATE_CERT:-1}
 if [ "$CREATE_CERT" = "1" ]; then
     if command -V tedge >/dev/null 2>&1; then
         if [ -n "$DEVICE_ID" ]; then
-            if [ ! -f /etc/tedge/device-certs/tedge-private-key.pem ]; then
+        PRIVATE_CERT=$(tedge config get device.key_path)
+        if [ ! -f "$PRIVATE_CERT" ]; then
                 tedge cert create --device-id "$DEVICE_ID"
-            fi
         fi
     fi
 fi

--- a/justfile
+++ b/justfile
@@ -27,8 +27,8 @@ build-child OUTPUT_TYPE='oci,dest=tedge-demo-child.tar' VERSION='latest':
     docker buildx build --platform linux/amd64,linux/arm64 -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-child:{{VERSION}} -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-child:latest -f images/child-device/child.dockerfile --output=type={{OUTPUT_TYPE}} images/child-device
 
 # Build the alpine s6 image
-build-main-s6 OUTPUT_TYPE='oci,dest=tedge-demo-main-s6.tar' VERSION='latest':
-    docker buildx build --platform linux/amd64,linux/arm64 -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-main-s6:{{VERSION}} -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-main-s6:latest -f images/alpine-s6/alpine-s6.dockerfile --output=type={{OUTPUT_TYPE}} images/alpine-s6
+build-main-s6 OUTPUT_TYPE='oci,dest=tedge-demo-s6.tar' VERSION='latest':
+    docker buildx build --platform linux/amd64,linux/arm64 -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-s6:{{VERSION}} -t {{REGISTRY}}/{{REPO_OWNER}}/tedge-demo-s6:latest -f images/alpine-s6/alpine-s6.dockerfile --output=type={{OUTPUT_TYPE}} images/alpine-s6
 
 # Build the mosquitto image (used with the alpine s6 image)
 build-mosquitto OUTPUT_TYPE='oci,dest=tedge-mosquitto.tar' VERSION='latest':

--- a/tests/alpine-s6/children/operations.robot
+++ b/tests/alpine-s6/children/operations.robot
@@ -33,6 +33,16 @@ Restart Device
 It Should List the Installed Software
     Device Should Have Installed Software    tedge    tedge-agent
 
+Install software (apk package)
+    ${operation}=    Install Software    jq,latest::apk
+    Operation Should Be SUCCESSFUL    ${operation}
+    Device Should Have Installed Software    jq
+
+Uninstall software (apk package)
+    ${operation}=     Uninstall Software    jq,latest::apk
+    Operation Should Be SUCCESSFUL    ${operation}
+    Device Should Not Have Installed Software    jq
+
 *** Keywords ***
 
 Revert Configuration

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.24.2
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.26.0
 robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.10.2


### PR DESCRIPTION
Cleanup s6-overlay image

* remove unused environment variables
* extend system tests to check installing/removing applications (though user: root is required) - Note: the default user is still tedge and not root in the demo docker compose file
* rename s6 overlay image name to tedge-demo-s6