### PR TITLE
feat: update debian base version and mosquitto

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -22,6 +22,19 @@ RUN apt-get -y update \
         libmnl0 \
         vim.tiny
 
+# Install more recent version of mosquitto >= 2.0.18 from debian sid to avoid mosquitto following bugs:
+# The mosquitto repo can't be used as it does not included builds for arm64/aarch64 (only amd64 and armhf)
+# * https://github.com/eclipse/mosquitto/issues/2604 (2.0.11)
+# * https://github.com/eclipse/mosquitto/issues/2634 (2.0.15)
+RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/debian-sid.list" \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        mosquitto \
+        mosquitto-clients \
+    # Remove sid afterwards to prevent unexpected packages from being installed
+    && rm -f /etc/apt/sources.list.d/debian-sid.list \
+    && apt-get update
+
 # Remove unnecessary systemd services
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /etc/systemd/system/*.wants/* \

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 
 ARG VERSION=
 
@@ -17,8 +17,6 @@ RUN apt-get -y update \
         systemd \
         systemd-sysv \
         ssh \
-        mosquitto \
-        mosquitto-clients \
         collectd-core \
         # extra collectd shared libraries
         libmnl0 \


### PR DESCRIPTION
Update debain base version and mosquitto.

### Debian bookworm

Bookworm has been officially released and using it so that the libc versions match those of the sid repository to enable installing the latest version of mosquitto (>=2.0.18) which is not currently available from the stable or backports of bookworm

### mosquitto >= 2.0.18
Install more recent version of mosquitto >= 2.0.18 from debian sid to avoid mosquitto following bugs:

The mosquitto repo can't be used as it does not included builds for arm64/aarch64 (only amd64 and armhf)
* https://github.com/eclipse/mosquitto/issues/2604 (2.0.11)
* https://github.com/eclipse/mosquitto/issues/2634 (2.0.15)