### PR TITLE
feat: send an event after bootstrapping

### DIFF
--- a/images/common/bootstrap.sh
+++ b/images/common/bootstrap.sh
@@ -464,6 +464,9 @@ main() {
         done
     fi
 
+    # use startup notifier to send the startup message after bootstrapping to indicate that thin-edge.io is up and running
+    sudo systemctl restart startup-notifier >/dev/null 2>&1 ||:
+
     if [ "$BOOTSTRAP" = 1 ] || [ "$CONNECT" = 1 ]; then
         display_banner_c8y
     fi


### PR DESCRIPTION
Improve user experience by also sending the startup event after the bootrapping. The event was not sent by default as the startup notifier only starts on container start, but the first time the container starts the mapper is not configured so the message is lost.

Using retain is a bad option as it produces duplicate messages on a normal container restart.