### PR TITLE
dev: support setting container IMAGE via environment variable

### DIFF
--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: "3"
 
-# child device template
+# device template
 x-device-defaults: &device-defaults
   build:
     dockerfile: alpine-s6.dockerfile

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set dotenv-load
 
 # Control which demo setup to use
 # IMAGE := "alpine-s6"
-IMAGE := "debian-systemd"
+IMAGE := env_var_or_default("IMAGE", "debian-systemd")
 
 REGISTRY := "ghcr.io"
 REPO_OWNER := "thin-edge"


### PR DESCRIPTION
Previously users would have to start the docker compose project using:

```
just IMAGE=alpine-s6 up
just IMAGE=alpine-s6 down
```

Now the `IMAGE` variable can be set in the environment (or `.env` file)

**file: .env**

```
IMAGE=alpine-s6
```

Then you can use the commands without having to set the `IMAGE=` each time.

```
just up
```
