### PR TITLE
test: add system test for uninstalling software

### DIFF
--- a/tests/debian-systemd/main/operations.robot
+++ b/tests/debian-systemd/main/operations.robot
@@ -21,9 +21,9 @@ Install software package
     Cumulocity.Device Should Have Installed Software    vim-tiny
 
 Uninstall software package
-    Skip    Missing Uninstall software keyword
-    ${operation}=    Cumulocity.Install Software    vim-tiny    timeout=90
+    ${operation}=    Cumulocity.Uninstall Software    vim-tiny    timeout=90
     Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Device Should Not Have Installed Software    vim-tiny
 
 Execute shell command
     ${operation}=    Cumulocity.Execute Shell Command    ls -l /etc/tedge

--- a/tests/debian-systemd/main/operations.robot
+++ b/tests/debian-systemd/main/operations.robot
@@ -21,7 +21,7 @@ Install software package
     Cumulocity.Device Should Have Installed Software    vim-tiny
 
 Uninstall software package
-    ${operation}=    Cumulocity.Uninstall Software    vim-tiny    timeout=90
+    ${operation}=    Cumulocity.Uninstall Software    vim-tiny,::apt    timeout=90
     Operation Should Be SUCCESSFUL    ${operation}
     Cumulocity.Device Should Not Have Installed Software    vim-tiny
 


### PR DESCRIPTION
Enable uninstall software test since the Cumulocity RobotFramework library now supports it.