### PR TITLE
systemd: skip any optional docker packages to reduce size of systemd image

### DIFF
--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -13,7 +13,10 @@ install_container_management () {
         | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     
     sudo apt-get update
-    sudo apt-get install -y docker-ce-cli docker-compose-plugin tedge-container-plugin
+    sudo apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+        docker-compose-plugin \
+        tedge-container-plugin
 
     # Disable services to prevent from starting too early
     # before thin-edge has been registered


### PR DESCRIPTION
Slim down on optional components and improve the build time of the systemd image by using `--no-install-recommends` when installing docker-ce-cli.