### PR TITLE
feat: add inventory-scripts package

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -77,6 +77,7 @@ RUN echo "running" \
     && curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/setup.deb.sh' | sudo -E bash \
     && systemctl enable collectd \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        tedge-inventory-plugin \
         c8y-command-plugin
 
 # Optional installations

--- a/tests/debian-systemd/main/telemetry.robot
+++ b/tests/debian-systemd/main/telemetry.robot
@@ -21,3 +21,20 @@ Service status
 Sends measurements
     ${date_from}=    Get Test Start Time
     Cumulocity.Device Should Have Measurements    minimum=1    after=${date_from}    timeout=120
+
+Inventory Script: OS information
+    ${mo}=    Cumulocity.Device Should Have Fragments    device_OS
+    Log    ${mo["device_OS"]}
+    Should Not Be Empty    ${mo["device_OS"]["arch"]}
+    Should Not Be Empty    ${mo["device_OS"]["displayName"]}
+    Should Not Be Empty    ${mo["device_OS"]["family"]}
+    Should Not Be Empty    ${mo["device_OS"]["hostname"]}
+    Should Not Be Empty    ${mo["device_OS"]["kernel"]}
+    Should Not Be Empty    ${mo["device_OS"]["version"]}
+
+Inventory Script: Hardware information
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Hardware
+    Log    ${mo["c8y_Hardware"]}
+    Should Not Be Empty    ${mo["c8y_Hardware"]["model"]}
+    Should Not Be Empty    ${mo["c8y_Hardware"]["serialNumber"]}
+    Should Not Be Empty    ${mo["c8y_Hardware"]["revision"]}


### PR DESCRIPTION
Publish inventory data such as hardware and OS information on device startup.

See the new community [tedge-inventory-plugin](https://github.com/thin-edge/tedge-inventory-plugin) for more details