### PR TITLE
chore: remove workarounds after related tickets have been merged

### DIFF
--- a/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
+++ b/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
@@ -9,9 +9,6 @@ x-device-defaults: &defaults
     - /tmp
   depends_on:
     - mqtt-broker
-  environment:
-    # Remove once: https://github.com/thin-edge/thin-edge.io/issues/2523
-    - TEDGE_ENABLE_SUDO=false
   # root is required in the default docker setup
   user: root
 
@@ -50,8 +47,6 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # main device
   tedge:
@@ -60,8 +55,6 @@ services:
     volumes:
       # Enable docker from docker - But then this container has elevated access to system resources!
       - /var/run/docker.sock:${DOCKER_SOCKET:-/var/run/docker.sock}:rw
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # monitor container/container-groups and add services on the main device
   tedge-container-monitor:
@@ -75,5 +68,3 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
-  # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-  tedge-data:

--- a/demos/docker-compose/tedge/docker-compose.yaml
+++ b/demos/docker-compose/tedge/docker-compose.yaml
@@ -9,9 +9,6 @@ x-device-defaults: &defaults
     - /tmp
   depends_on:
     - mqtt-broker
-  environment:
-    # Remove once: https://github.com/thin-edge/thin-edge.io/issues/2523
-    - TEDGE_ENABLE_SUDO=false
 
 services:
   bootstrap:
@@ -48,16 +45,11 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # main device
   tedge:
     <<: *defaults
     command: ["/usr/bin/tedge-agent", "--mqtt-device-topic-id", "device/main//"]
-    volumes:
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # child devices
   child01:
@@ -68,5 +60,3 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
-  # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-  tedge-data:

--- a/images/tedge-containermgmt/docker-compose.yaml
+++ b/images/tedge-containermgmt/docker-compose.yaml
@@ -11,9 +11,6 @@ x-device-defaults: &defaults
     - /tmp
   depends_on:
     - mqtt-broker
-  environment:
-    # Remove once: https://github.com/thin-edge/thin-edge.io/issues/2523
-    - TEDGE_ENABLE_SUDO=false
   # root is required in the default docker setup
   user: root
 
@@ -52,8 +49,6 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # main device
   tedge:
@@ -62,8 +57,6 @@ services:
     volumes:
       # Enable docker from docker - But then this container has elevated access to system resources!
       - /var/run/docker.sock:${DOCKER_SOCKET:-/var/run/docker.sock}:rw
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # monitor container/container-groups and add services on the main device
   tedge-container-monitor:
@@ -77,5 +70,3 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
-  # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-  tedge-data:

--- a/images/tedge/docker-compose.yaml
+++ b/images/tedge/docker-compose.yaml
@@ -11,9 +11,6 @@ x-device-defaults: &defaults
     - /tmp
   depends_on:
     - mqtt-broker
-  environment:
-    # Remove once: https://github.com/thin-edge/thin-edge.io/issues/2523
-    - TEDGE_ENABLE_SUDO=false
 
 services:
   bootstrap:
@@ -50,16 +47,11 @@ services:
       - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # main device
   tedge:
     <<: *defaults
     command: ["/usr/bin/tedge-agent", "--mqtt-device-topic-id", "device/main//"]
-    volumes:
-      # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-      - tedge-data:/var/tedge
 
   # child devices
   child01:
@@ -70,5 +62,3 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
-  # Remove once https://github.com/thin-edge/thin-edge.io/issues/2477 is resolved
-  tedge-data:


### PR DESCRIPTION
Removing workarounds after updating thin-edge.io since the following tickets have now been merged:

* https://github.com/thin-edge/thin-edge.io/issues/2523
* https://github.com/thin-edge/thin-edge.io/issues/2477
