### PR TITLE
ci: support local workflow runs using act on arm64 systems

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,25 @@ jobs:
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
           cat .env
 
-      - uses: actions/setup-python@v4
+      - name: Detect host architecture
+        run: |
+          arch=$(uname -m)
+          case "$arch" in
+            arm64|aarch64) NORMALIZED_ARCH=arm64; ;;
+            amd64|x86_64) NORMALIZED_ARCH=amd64; ;;
+            *) NORMALIZED_ARCH="$arch"; ;;
+          esac
+          echo "ARCH=$NORMALIZED_ARCH" >> "$GITHUB_ENV"
+
+
+      # Support running workflow locally on arm64 systems using act
+      # https://github.com/actions/setup-python/issues/705#issuecomment-1756948951
+      - if: ${{ env.ARCH == 'arm64' }}
+        uses: deadsnakes/action@v2.1.1
+        with:
+          python-version: "3.9"
+      - if: ${{ env.ARCH == 'amd64' }}
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/docs/TESTING_WORKFLOW.md
+++ b/docs/TESTING_WORKFLOW.md
@@ -20,10 +20,8 @@ act push -s GITHUB_TOKEN=$(gh auth token)
 
 ## Tests
 
-The test workflow needs to be run using `linux/amd64` containers as the `setup-python` action only supports the amd64 platform.
-
 ```sh
-act push -j test -s GITHUB_TOKEN=$(gh auth token) --container-architecture linux/amd64 --secret-file .env --artifact-server-path ./tmp
+act push -j test -s GITHUB_TOKEN=$(gh auth token) --secret-file .env --artifact-server-path ./tmp
 ```
 
 ## FAQ


### PR DESCRIPTION
Use deadsnakes gha when running on an arm64. This makes it easier and quicker to test the workflow locally using act on arm64 machines.