### PR TITLE
ci: skip building the image when calling up

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
                   UP_PID=$!
 
                   sleep 5
-                  just IMAGE=${{matrix.job.target}} bootstrap-container "$DEVICE_ID"
+                  just IMAGE=${{matrix.job.target}} bootstrap-container "$DEVICE_ID" </dev/null
                   
                   # Wait until bootstrap is ready
                   wait "$UP_PID"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
               container)
                   just IMAGE=${{matrix.job.target}} prepare-up
                   # Wait for container to startup before doing bootstrapping
-                  just IMAGE=${{matrix.job.target}} up >/dev/null 2>&1 &
+                  just IMAGE=${{matrix.job.target}} up --build=false >/dev/null 2>&1 &
                   UP_PID=$!
 
                   sleep 5

--- a/images/tedge-containermgmt/Dockerfile
+++ b/images/tedge-containermgmt/Dockerfile
@@ -2,7 +2,8 @@ FROM ghcr.io/thin-edge/tedge-main:latest
 
 # Install additional community plugins
 USER root
-RUN wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
+RUN apk update \
+    && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
         c8y-command-plugin \
@@ -10,7 +11,8 @@ RUN wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C
         # Containerization defaults
         tedge-container-plugin \
         docker-cli \
-        docker-compose
+        docker-compose \
+    && apk cache clean
 
 # Add custom config
 COPY tedge-log-plugin.toml /etc/tedge/plugins/

--- a/images/tedge/Dockerfile
+++ b/images/tedge/Dockerfile
@@ -2,11 +2,13 @@ FROM ghcr.io/thin-edge/tedge-main:latest
 
 # Install additional community plugins
 USER root
-RUN wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
+RUN apk update \
+    && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
         c8y-command-plugin \
-        tedge-apk-plugin
+        tedge-apk-plugin \
+    && apk cache clean
 
 # Add custom config
 COPY tedge-log-plugin.toml /etc/tedge/plugins/

--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ create-env:
 
 # Prepare up but don't start any containers
 prepare-up *args='':
-    docker compose --env-file {{DEV_ENV}} -f images/{{IMAGE}}/docker-compose.yaml up -d --build --no-start {{args}}
+    docker compose --env-file {{DEV_ENV}} -f images/{{IMAGE}}/docker-compose.yaml build {{args}}
 
 # Start the demo
 up *args='':


### PR DESCRIPTION
Avoid rebuilding the project when starting containers used in the tests (as the containers are pre-built)