### PR TITLE
remove reliance on bootstrap environment variables

### DIFF
--- a/demos/docker-compose/tedge-containermgmt/README.md
+++ b/demos/docker-compose/tedge-containermgmt/README.md
@@ -29,15 +29,19 @@ After you have installed these, then you will also need to setup a go-c8y-cli se
     wget https://raw.githubusercontent.com/thin-edge/tedge-demo-container/main/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
     ```
 
-2. Activate your go-c8y-cli session to connect to the Cumulocity IoT Instance
-
-3. Start the docker-compose project (in the background)
+2. Start the docker-compose project (in the background)
 
     ```sh
     docker compose up -d
     ```
 
-4. In a new console, set the same c8y session, then bootstrap the device
+3. Open a new console, and activate your go-c8y-cli session which points to the Cumulocity IoT Instance you wish to connect the device to
+
+    ```
+    set-session
+    ```
+
+4. Bootstrap the device
 
     ```sh
     c8y tedge bootstrap-container bootstrap example001

--- a/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
+++ b/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
@@ -20,8 +20,6 @@ services:
     stop_grace_period: "2s"
     pull_policy: always
     user: root
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     command:
       - sh
       - -c
@@ -29,6 +27,7 @@ services:
     volumes:
       - device-certs:/etc/tedge/device-certs
       - mosquitto-conf:/etc/tedge/mosquitto-conf
+      - tedge:/etc/tedge
 
   mqtt-broker:
     image: ghcr.io/thin-edge/tedge-mqtt-broker:${VERSION:-latest}
@@ -47,10 +46,10 @@ services:
   tedge-mapper-c8y:
     <<: *defaults
     command: ["/usr/bin/tedge-mapper", "c8y"]
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # Required only for the c8y.url
+      - tedge:/etc/tedge
 
   # main device
   tedge:
@@ -72,6 +71,7 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
+  tedge:
 
 networks:
   tedge:

--- a/demos/docker-compose/tedge/README.md
+++ b/demos/docker-compose/tedge/README.md
@@ -29,15 +29,19 @@ After you have installed these, then you will also need to setup a go-c8y-cli se
     wget https://raw.githubusercontent.com/thin-edge/tedge-demo-container/main/demos/docker-compose/tedge/docker-compose.yaml
     ```
 
-2. Activate your go-c8y-cli session to connect to the Cumulocity IoT Instance
-
-3. Start the docker-compose project (in the background)
+2. Start the docker-compose project (in the background)
 
     ```sh
     docker compose up -d
     ```
 
-4. In a new console, set the same c8y session, then bootstrap the device
+3. Open a new console, and activate your go-c8y-cli session which points to the Cumulocity IoT Instance you wish to connect the device to
+
+    ```
+    set-session
+    ```
+
+4. Bootstrap the device
 
     ```sh
     c8y tedge bootstrap-container bootstrap example001

--- a/demos/docker-compose/tedge/docker-compose.yaml
+++ b/demos/docker-compose/tedge/docker-compose.yaml
@@ -16,8 +16,6 @@ services:
     stop_grace_period: "2s"
     pull_policy: always
     user: root
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     command:
       - sh
       - -c
@@ -25,6 +23,7 @@ services:
     volumes:
       - device-certs:/etc/tedge/device-certs
       - mosquitto-conf:/etc/tedge/mosquitto-conf
+      - tedge:/etc/tedge
 
   mqtt-broker:
     image: ghcr.io/thin-edge/tedge-mqtt-broker:${VERSION:-latest}
@@ -41,10 +40,10 @@ services:
   tedge-mapper-c8y:
     <<: *defaults
     command: ["/usr/bin/tedge-mapper", "c8y"]
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # Required only for the c8y.url
+      - tedge:/etc/tedge
 
   # main device
   tedge:
@@ -60,3 +59,4 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
+  tedge:

--- a/images/tedge-containermgmt/docker-compose.yaml
+++ b/images/tedge-containermgmt/docker-compose.yaml
@@ -18,12 +18,12 @@ x-device-defaults: &defaults
 
 services:
   bootstrap:
-    image: ghcr.io/thin-edge/tedge-main:latest
+    build:
+      dockerfile: Dockerfile
+      context: "."
     stop_grace_period: "2s"
     pull_policy: always
     user: root
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     command:
       - sh
       - -c
@@ -31,6 +31,7 @@ services:
     volumes:
       - device-certs:/etc/tedge/device-certs
       - mosquitto-conf:/etc/tedge/mosquitto-conf
+      - tedge:/etc/tedge
 
   mqtt-broker:
     image: ghcr.io/thin-edge/tedge-mqtt-broker:${VERSION:-latest}
@@ -49,10 +50,10 @@ services:
   tedge-mapper-c8y:
     <<: *defaults
     command: ["/usr/bin/tedge-mapper", "c8y"]
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # Required only for the c8y.url
+      - tedge:/etc/tedge
 
   # main device
   tedge:
@@ -74,6 +75,7 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
+  tedge:
 
 networks:
   tedge:

--- a/images/tedge/docker-compose.yaml
+++ b/images/tedge/docker-compose.yaml
@@ -17,12 +17,12 @@ x-device-defaults: &defaults
 
 services:
   bootstrap:
-    image: ghcr.io/thin-edge/tedge-main:latest
+    build:
+      dockerfile: Dockerfile
+      context: "."
     stop_grace_period: "2s"
     pull_policy: always
     user: root
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     command:
       - sh
       - -c
@@ -30,6 +30,7 @@ services:
     volumes:
       - device-certs:/etc/tedge/device-certs
       - mosquitto-conf:/etc/tedge/mosquitto-conf
+      - tedge:/etc/tedge
 
   mqtt-broker:
     image: ghcr.io/thin-edge/tedge-mqtt-broker:${VERSION:-latest}
@@ -46,10 +47,10 @@ services:
   tedge-mapper-c8y:
     <<: *defaults
     command: ["/usr/bin/tedge-mapper", "c8y"]
-    environment:
-      - TEDGE_C8Y_URL=${C8Y_DOMAIN:-}
     volumes:
       - device-certs:/etc/tedge/device-certs
+      # Required only for the c8y.url
+      - tedge:/etc/tedge
 
   # main device
   tedge:
@@ -65,3 +66,4 @@ volumes:
   device-certs:
   mosquitto:
   mosquitto-conf:
+  tedge:


### PR DESCRIPTION
Instead all of the bootstrapping settings will be injected during the runtime bootstrapping commands. This reduces dependencies between starting the docker compose and running the bootstrapping.