### PR TITLE
dev: add a release task

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,8 @@
 set positional-arguments
 set dotenv-load
 
+RELEASE_VERSION := env_var_or_default("RELEASE_VERSION", `date +'%Y%m%d.%H%M'`)
+
 # Control which demo setup to use
 # IMAGE := "alpine-s6"
 IMAGE := env_var_or_default("IMAGE", "debian-systemd")
@@ -111,3 +113,11 @@ cleanup DEVICE_ID $CI="true":
     c8y devicemanagement certificates list -n --tenant "$(c8y currenttenant get --select name --output csv)" --filter "name eq {{DEVICE_ID}}" --pageSize 2000 | c8y devicemanagement certificates delete --tenant "$(c8y currenttenant get --select name --output csv)"
     c8y inventory find -n --owner "device_{{DEVICE_ID}}" -p 100 | c8y inventory delete
     c8y users delete -n --id "device_{{DEVICE_ID}}" --tenant "$(c8y currenttenant get --select name --output csv)" --silentStatusCodes 404 --silentExit
+
+# Trigger a release (by creating a tag)
+release:
+    git tag -a "{{RELEASE_VERSION}}" -m "{{RELEASE_VERSION}}"
+    git push origin "{{RELEASE_VERSION}}"
+    @echo
+    @echo "Created release (tag): {{RELEASE_VERSION}}"
+    @echo


### PR DESCRIPTION
Add a release task to ensure consistent naming of releases.

**Example**

```sh
just release
```