### PR TITLE
refactor: remove manual community repo setup

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -74,7 +74,6 @@ RUN systemctl enable register-operations.service
 
 RUN echo "running" \
     && wget -O - thin-edge.io/install.sh | sh -s \
-    && curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/setup.deb.sh' | sudo -E bash \
     && systemctl enable collectd \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         tedge-inventory-plugin \


### PR DESCRIPTION
The community repo is already configured by the thin-edge.io install.sh script.