### PR TITLE
ci: use taiki-e/install-action@just to install just

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,9 +31,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: extractions/setup-just@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@just
 
       - name: Publish images
         run: just build registry ${{ inputs.VERSION || github.ref_name }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,9 +95,7 @@ jobs:
           cache-dependency-path: |
             tests/requirements.txt
 
-      - uses: extractions/setup-just@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@just
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
switch the action to install just in the workflows to avoid the node16.x deprecation notices which are present on the previously used action.