### PR TITLE
feat(software): use software package exclusion pattern to ignore uninteresting packages

### DIFF
--- a/images/common/config/tedge.toml
+++ b/images/common/config/tedge.toml
@@ -11,5 +11,6 @@ client.host = "tedge"
 proxy.bind.address = "0.0.0.0"
 proxy.client.host = "tedge"
 
-[apt]
-name = "(tedge|c8y|python|wget|vim|curl|apt|mosquitto|ssh|sudo).*"
+[software.plugin]
+# Exclude uninteresting software management packages (regardless of type)
+exclude = "^(glibc|lib|kernel-|iptables-module).*"

--- a/tests/debian-systemd/main/operations.robot
+++ b/tests/debian-systemd/main/operations.robot
@@ -20,6 +20,9 @@ Install software package
     Operation Should Be SUCCESSFUL    ${operation}    timeout=90
     Cumulocity.Device Should Have Installed Software    vim-tiny
 
+    # lib* packages should be excluded by default due to the custom tedge.toml config
+    Cumulocity.Device Should Not Have Installed Software    libc-bin
+
 Uninstall software package
     ${operation}=    Cumulocity.Uninstall Software    {"name": "vim-tiny", "softwareType": "apt"}    timeout=90
     Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
thin-edge.io 1.1.0 supports a new software management package exclusion filter to ignore uninteresting packages.

Previously an "inclusion" filter was being used (via. apt.name), however this resulted in unexpected behaviour for users wanting to install new packages which didn't match the filter (see [#79](https://github.com/thin-edge/tedge-demo-container/issues/79)).