### PR TITLE
fix: install mosquitto from bookworm-backports

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -22,18 +22,15 @@ RUN apt-get -y update \
         libmnl0 \
         vim.tiny
 
-# Install more recent version of mosquitto >= 2.0.18 from debian sid to avoid mosquitto following bugs:
+# Install more recent version of mosquitto >= 2.0.18 from debian backports to avoid mosquitto following bugs:
 # The mosquitto repo can't be used as it does not included builds for arm64/aarch64 (only amd64 and armhf)
 # * https://github.com/eclipse/mosquitto/issues/2604 (2.0.11)
 # * https://github.com/eclipse/mosquitto/issues/2634 (2.0.15)
-RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/debian-sid.list" \
+RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/debian-bookworm-backports.list" \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -t bookworm-backports \
         mosquitto \
-        mosquitto-clients \
-    # Remove sid afterwards to prevent unexpected packages from being installed
-    && rm -f /etc/apt/sources.list.d/debian-sid.list \
-    && apt-get update
+        mosquitto-clients
 
 # Remove unnecessary systemd services
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \


### PR DESCRIPTION
Install mosquitto from bookworm-backports over sid to avoid unexpected changes to core packages (e.g. systemd, libc etc.).