### PR TITLE
fix: enable ssh access out of the box

### DIFF
--- a/images/common/bootstrap.sh
+++ b/images/common/bootstrap.sh
@@ -389,28 +389,6 @@ display_banner_c8y() {
     echo "----------------------------------------------------------"    
 }
 
-configure_test_user() {
-    if [ -n "$TEST_USER" ]; then
-        if ! id -u "$TEST_USER" >/dev/null 2>&1; then
-            sudo useradd -ms /bin/bash "${TEST_USER}" && echo "${TEST_USER}:${TEST_USER}" | sudo chpasswd && sudo adduser "${TEST_USER}" sudo
-        fi
-    fi
-}
-
-post_configure() {
-    echo "Setting sudoers.d config"
-    if [ ! -f /etc/sudoers.d/all ]; then
-        sudo sh -c "echo '%sudo ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/all"
-    fi
-
-    echo "Add tedge to the admin group to give it access to monitoring files"
-    usermod -a -G adm tedge ||:
-
-    if [ ! -f /etc/sudoers.d/tedge ]; then
-        sudo sh -c "echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /bin/systemctl, /bin/journalctl, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge"
-    fi
-}
-
 main() {
     # ---------------------------------------
     # Bootstrap
@@ -437,18 +415,11 @@ main() {
     # Post setup
     # ---------------------------------------
     if [ "$CONFIGURE_TEST_SETUP" = 1 ]; then
-        configure_test_user
-        post_configure
-
         # Add additional tools
         if command_exists systemctl; then
             if [ -d /run/systemd/system ]; then
-                sudo systemctl start ssh
                 sudo systemctl restart tedge-agent
                 sudo systemctl restart c8y-firmware-plugin
-
-                sudo systemctl enable tedge-mapper-collectd
-                sudo systemctl start tedge-mapper-collectd
             fi
         fi
     fi

--- a/images/common/config/sshd_config
+++ b/images/common/config/sshd_config
@@ -1,0 +1,122 @@
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin:/bin:/usr/games
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Include /etc/ssh/sshd_config.d/*.conf
+
+Port 22
+AddressFamily any
+ListenAddress 127.0.0.1
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile     .ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+KbdInteractiveAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin prohibit-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+# NOTE: This is a demo setup and not a production setting, so it is ok to disable.
+UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem       sftp    /usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+TEST_USER=${TEST_USER:-iotadmin}
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
 install_container_management () {
     sudo install -m 0755 -d /etc/apt/keyrings
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -26,7 +30,36 @@ install_container_management () {
     fi
 }
 
+configure_users() {
+    if [ -n "$TEST_USER" ]; then
+        if ! id -u "$TEST_USER" >/dev/null 2>&1; then
+            sudo useradd -ms /bin/bash "${TEST_USER}" && echo "${TEST_USER}:${TEST_USER}" | sudo chpasswd && sudo adduser "${TEST_USER}" sudo
+        fi
+    fi
+
+    echo "Setting sudoers.d config"
+    if [ ! -f /etc/sudoers.d/all ]; then
+        sudo sh -c "echo '%sudo ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/all"
+    fi
+
+    echo "Add tedge to the admin group to give it access to monitoring files"
+    usermod -a -G adm tedge ||:
+
+    if [ ! -f /etc/sudoers.d/tedge ]; then
+        sudo sh -c "echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /bin/systemctl, /bin/journalctl, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge"
+    fi
+}
+
+configure_services() {
+    if command_exists systemctl; then
+        sudo systemctl enable ssh
+        sudo systemctl enable tedge-mapper-collectd
+    fi
+}
+
 main() {
+    configure_users
+    configure_services
     install_container_management
 }
 

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -75,6 +75,8 @@ RUN echo "running" \
         tedge-inventory-plugin \
         c8y-command-plugin
 
+COPY common/config/sshd_config /etc/ssh/sshd_config
+
 # Optional installations
 COPY common/optional-installer.sh .
 RUN ./optional-installer.sh

--- a/tests/debian-systemd/main/system.robot
+++ b/tests/debian-systemd/main/system.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Resource    ../../resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary
+
+Suite Setup    Set Main Device
+
+*** Test Cases ***
+
+SSH daemon should be running by default
+    ${operation}=    Cumulocity.Execute Shell Command    sudo systemctl is-active ssh
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/debian-systemd/main/system.robot
+++ b/tests/debian-systemd/main/system.robot
@@ -10,3 +10,7 @@ Suite Setup    Set Main Device
 SSH daemon should be running by default
     ${operation}=    Cumulocity.Execute Shell Command    sudo systemctl is-active ssh
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
+
+Test user should be present by default
+    ${operation}=    Cumulocity.Execute Shell Command    grep -q iotadmin /etc/passwd
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
To resolve https://github.com/thin-edge/tedge-demo-container/issues/83, the following changes were made to enable ssh out of the box (again):

* Create the `iotadmin` user at build time rather than during the bootstrap.sh script (just in case if people are manually bootstrapping the device or using [c8y-tedge](https://github.com/thin-edge/c8y-tedge)).
* Include sshd config which allows ssh users to login with a password (though ssh will only listen on the loopback address, 127.0.0.1)

