### PR TITLE
chore: remove deprecated docker compose version field

### DIFF
--- a/demos/docker-compose/device/docker-compose.yaml
+++ b/demos/docker-compose/device/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 # child device template
 x-child-defaults: &child-defaults
   image: ghcr.io/thin-edge/tedge-demo-child:${VERSION:-latest}

--- a/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
+++ b/demos/docker-compose/tedge-containermgmt/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # device template
 x-device-defaults: &defaults
   image: ghcr.io/thin-edge/tedge-demo-containermgmt:${VERSION:-latest}

--- a/demos/docker-compose/tedge/docker-compose.yaml
+++ b/demos/docker-compose/tedge/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # device template
 x-device-defaults: &defaults
   image: ghcr.io/thin-edge/tedge-demo:${VERSION:-latest}

--- a/images/alpine-s6/docker-compose.yaml
+++ b/images/alpine-s6/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # device template
 x-device-defaults: &device-defaults
   build:

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 # child device template
 x-child-defaults: &child-defaults
   build:

--- a/images/tedge-containermgmt/docker-compose.yaml
+++ b/images/tedge-containermgmt/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # device template
 x-device-defaults: &defaults
   build:

--- a/images/tedge/docker-compose.yaml
+++ b/images/tedge/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 # device template
 x-device-defaults: &defaults
   build:

--- a/tests/tedge-containermgmt/data/docker-compose.nginx.yaml
+++ b/tests/tedge-containermgmt/data/docker-compose.nginx.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx:
     image: nginx


### PR DESCRIPTION
Remove the usage of the deprecated docker compose version field, to address these warnings:

```
WARN[0000] example/docker-compose.yaml: `version` is obsolete
```