### PR TITLE
feat: set default software type to apt

### DIFF
--- a/images/common/config/tedge.toml
+++ b/images/common/config/tedge.toml
@@ -14,3 +14,6 @@ proxy.client.host = "tedge"
 [software.plugin]
 # Exclude uninteresting software management packages (regardless of type)
 exclude = "^(glibc|lib|kernel-|iptables-module).*"
+# Default package type it it is not set.
+# Useful when applying device profiles as the softwareType info can be stripped from the software items
+default = "apt"


### PR DESCRIPTION
Useful when applying device profiles from the cloud where the softwareType can be left out. Setting the default type to `apt` is a sensible default for the systemd container as it is debian based.