### PR TITLE
feat: add tedge-log-plugin to files which can be managed by tedge-configuration-plugin

### DIFF
--- a/images/common/config/tedge-configuration-plugin.toml
+++ b/images/common/config/tedge-configuration-plugin.toml
@@ -1,5 +1,6 @@
 files = [
     { path = '/etc/tedge/tedge.toml', type = 'tedge.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/plugins/tedge-log-plugin.toml', type = 'tedge-log-plugin', user = 'tedge', group = 'tedge', mode = 0o644 },
     { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
     { path = '/etc/mosquitto/conf.d/mosquitto.conf', type = 'mosquitto.conf', user = 'root', group = 'root', mode = 0o644 },
     { path = '/etc/collectd/collectd.conf', type = 'collectd.conf', user = 'root', group = 'root', mode = 0o644 },


### PR DESCRIPTION
Allow management of the tedge-log-plugin out of the box by including it in the default tedge-configuration-plugin.toml configuration.