### PR TITLE
ci: stop test containers before uploading report

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,17 +133,16 @@ jobs:
       - name: Run tests
         run: just IMAGE=${{matrix.job.target}} test
 
+      - name: Stop demo
+        if: always()
+        run: just IMAGE=${{matrix.job.target}} down-all
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-${{matrix.job.target}}
           path: output
-
-      - name: Stop demo
-        if: always()
-        run: just IMAGE=${{matrix.job.target}} down-all
-
 
       - name: Cleanup Devices
         if: always()


### PR DESCRIPTION
This change allows the just file task to be extended to add additional test log files collected when shutting down the containers (but the collection of the logs files will be implemented in a follow up PR)