### PR TITLE
chore: remove unused python requirements file

### DIFF
--- a/images/child-device/requirements.txt
+++ b/images/child-device/requirements.txt
@@ -1,3 +1,0 @@
-paho-mqtt==1.6.1
-requests==2.31.0
-psutil==5.9.4


### PR DESCRIPTION
Remove a python requirements file which is no longer used after the python agent code was moved to https://github.com/thin-edge/python-tedge-agent