### PR TITLE
ci: collect container log files before destroying it to assist debugging failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 log.html
 output.xml
 report.html
+output/
 
 # misc
 .DS_Store

--- a/justfile
+++ b/justfile
@@ -70,8 +70,9 @@ up-no-cache *args='':
 down:
     docker compose --env-file {{DEV_ENV}} -f images/{{IMAGE}}/docker-compose.yaml down
 
-# Stop the demo and destroy the data
+# Collect logs files then stop and destroy the demo and all of its data
 down-all:
+    just -f {{justfile()}} DEV_ENV={{DEV_ENV}} IMAGE={{IMAGE}} collect-logs ||:
     docker compose --env-file {{DEV_ENV}} -f images/{{IMAGE}}/docker-compose.yaml down -v
 
 # Configure and register the device to the cloud
@@ -121,3 +122,7 @@ release:
     @echo
     @echo "Created release (tag): {{RELEASE_VERSION}}"
     @echo
+
+# Collect logs
+collect-logs output="output/logs":
+    COMPOSE_FILE="images/{{IMAGE}}/docker-compose.yaml" ./scripts/collect-logs.sh

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -19,7 +19,7 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [ "$DEBUG" = 1 ]; then
+if [ "$DEBUG" = 1 ] || [ -n "$CI" ]; then
     set -x
 fi
 

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -e
+
+COMPOSE_FILE=${COMPOSE_FILE:-}
+export COMPOSE_FILE
+
+MAX_LINES=10000
+COLLATE_LOGS=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --collate)
+            COLLATE_LOGS=1
+            ;;
+        --debug)
+            DEBUG=1
+            ;;
+    esac
+    shift
+done
+
+if [ "$DEBUG" = 1 ]; then
+    set -x
+fi
+
+is_systemd_container() {
+    name="$1"
+    docker compose exec "$name" sh -c 'command -V systemctl >/dev/null 2>&1'
+}
+
+collect_systemd_logs() {
+    echo "Collecting systemd logs" >&2
+    name="$1"
+    docker compose exec "$name" journalctl --no-pager -n "$MAX_LINES"
+}
+
+collect_container_logs() {
+    echo "Collecting container logs" >&2
+    if [ $# -gt 0 ]; then
+        name="$1"
+        docker compose logs "$name" -n "$MAX_LINES"
+    else
+        docker compose logs -n "$MAX_LINES"
+    fi
+}
+
+collect_logs() {
+    name="$1"
+    output_dir="$2"
+    if is_systemd_container "$name"; then
+        collect_systemd_logs "$name"
+    else
+        collect_container_logs "$name"
+    fi
+}
+
+collect_workflow_logs() {
+    name="$1"
+    output_dir="$2"
+    LOG_PATH=$(docker compose exec "$name" tedge config get logs.path)
+    docker compose cp "$name":"$LOG_PATH/agent/" "$output_dir/" >&2 ||:
+}
+
+collect_logs_collated() {
+    collect_container_logs
+}
+
+archive() {
+    SRC_DIR="$1"
+    OUTPUT_DIR="$2"
+    TMP_FILE="$(mktemp).tar.gz"
+    (cd "$SRC_DIR" && tar czvf "$TMP_FILE" .)
+
+    rm -r "$SRC_DIR"
+    mkdir -p "$OUTPUT_DIR"
+    ARCHIVE_FILE="$OUTPUT_DIR/logs.tar.gz"
+    echo "Creating log archive: $ARCHIVE_FILE" >&2
+    mv "$TMP_FILE" "$ARCHIVE_FILE"
+}
+
+get_services() {
+    docker compose ps --format "{{.Service}}" | sort
+}
+
+main() {
+    OUTPUT_DIR=output/logs
+    if [ "$COLLATE_LOGS" = 1 ]; then
+        mkdir -p "$OUTPUT_DIR/tedge"
+        collect_logs_collated "$OUTPUT_DIR" > "${name}.log"
+        collect_workflow_logs tedge "$OUTPUT_DIR"
+    else
+        for name in $(get_services); do
+            echo "Reading logs for service: $name" >&2
+            mkdir -p "$OUTPUT_DIR/$name"
+            collect_logs "$name" > "$OUTPUT_DIR/$name/${name}.log"
+            collect_workflow_logs "$name" "$OUTPUT_DIR/$name"
+        done
+    fi
+
+    archive "$OUTPUT_DIR" "$(dirname "$OUTPUT_DIR")"
+}
+
+main

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -57,8 +57,14 @@ collect_logs() {
 collect_workflow_logs() {
     name="$1"
     output_dir="$2"
-    LOG_PATH=$(docker compose exec "$name" tedge config get logs.path)
-    docker compose cp "$name":"$LOG_PATH/agent/" "$output_dir/" >&2 ||:
+    # Try and get the thin-edge.io log path. It could fail if the container
+    # does not have tedge installed
+    LOG_PATH=$(docker compose exec "$name" tedge config get logs.path ||:)
+    if [ -n "$LOG_PATH" ]; then
+        echo "Copying thin-edge.io workflow files" >&2
+        # Don't fail if there are no files to collect
+        docker compose cp "$name":"$LOG_PATH/agent/" "$output_dir/" >&2 ||:
+    fi
 }
 
 collect_logs_collated() {


### PR DESCRIPTION
Automatically collect container log files and workflows before destroying the container setup to assist debugging system test failures.