### PR TITLE
feat(debian-systemd): use mtls for all thin-edge.io components by using smallstep as local pki

### DIFF
--- a/images/child-device-container/child.dockerfile
+++ b/images/child-device-container/child.dockerfile
@@ -8,10 +8,16 @@ RUN apk add --no-cache \
     && curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
         tedge-apk-plugin \
-    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /bin/kill" > /etc/sudoers.d/tedge
+        tedge-pki-smallstep-client \
+    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /bin/kill" > /etc/sudoers.d/tedge \
+    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/step-ca-admin.sh, /usr/bin/enroll.sh, /usr/sbin/update-ca-certificates" > /etc/sudoers.d/step-ca \
+    # Allow tedge user to control this folder
+    && mkdir -p /etc/step-ca \
+    && chown -R tedge:tedge /etc/step-ca
 
 USER tedge
 COPY child-device-container/config/tedge-configuration-plugin.toml /etc/tedge/plugins/
+COPY common/utils/enroll/enroll.sh /usr/bin/
 COPY child-device-container/entrypoint.sh /app/
 COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/
 ENV TEDGE_MQTT_CLIENT_HOST=tedge

--- a/images/child-device-container/child.dockerfile
+++ b/images/child-device-container/child.dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache \
         tedge-apk-plugin \
         tedge-pki-smallstep-client \
     && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /bin/kill" > /etc/sudoers.d/tedge \
-    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/step-ca-admin.sh, /usr/bin/enroll.sh, /usr/sbin/update-ca-certificates" > /etc/sudoers.d/step-ca \
+    && echo "Defaults        env_keep += \"FEATURES\"" > /etc/sudoers.d/step-ca \
+    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/step-ca-admin.sh, /usr/bin/enroll.sh, /usr/sbin/update-ca-certificates" >> /etc/sudoers.d/step-ca \
     # Allow tedge user to control this folder
     && mkdir -p /etc/step-ca \
     && chown -R tedge:tedge /etc/step-ca

--- a/images/child-device-container/entrypoint.sh
+++ b/images/child-device-container/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 set -e
 
+# Enroll device with mtls
+PROVISION_PASSWORD_FILE=/tmp/provisioner-password
+if [ -n "$PROVISION_PASSWORD" ]; then
+    printf -- '%s' "$PROVISION_PASSWORD" > "$PROVISION_PASSWORD_FILE"
+    chmod 600 "$PROVISION_PASSWORD_FILE"
+fi
+(cd /tmp && sudo /usr/bin/enroll.sh --no-inherit-env --provisioner-password-file "$PROVISION_PASSWORD_FILE")
+rm -f "$PROVISION_PASSWORD_FILE"
+
 # start agent
 exec /usr/bin/tedge-agent

--- a/images/child-device-container/entrypoint.sh
+++ b/images/child-device-container/entrypoint.sh
@@ -7,6 +7,8 @@ if [ -n "$PROVISION_PASSWORD" ]; then
     printf -- '%s' "$PROVISION_PASSWORD" > "$PROVISION_PASSWORD_FILE"
     chmod 600 "$PROVISION_PASSWORD_FILE"
 fi
+
+# Note: The FEATURES variable MUST BE included in the env_keep seting of the sudoers file
 (cd /tmp && sudo /usr/bin/enroll.sh --no-inherit-env --provisioner-password-file "$PROVISION_PASSWORD_FILE")
 rm -f "$PROVISION_PASSWORD_FILE"
 

--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -42,6 +42,8 @@ RUN echo "running" \
         tedge-agent \
         tedge-apt-plugin \
         tedge-inventory-plugin \
+        # Local PKI service for easy child device registration
+        tedge-pki-smallstep-client \
     # Disable mosquitto as it is not needed on a child device
     && systemctl disable mosquitto.service \
     && systemctl mask mosquitto.service \
@@ -60,6 +62,12 @@ COPY common/utils/configure-device/runner.sh /usr/share/configure-device/
 COPY common/utils/configure-device/scripts.d/* /usr/share/configure-device/scripts.d/
 COPY common/utils/configure-device/configure-device.service /lib/systemd/system/
 RUN systemctl enable configure-device.service
+
+# add mtls enablement script. Store script under /usr/bin so it can also be manually called
+COPY common/utils/enroll/enroll.sh /usr/bin/
+RUN ln -sf /usr/bin/enroll.sh /usr/share/configure-device/scripts.d/70_enable_mtls
+# COPY common/utils/enroll/enroll.service /usr/lib/systemd/system/
+# RUN systemctl enable enroll.service
 
 COPY child-device-systemd/config/system.toml /etc/tedge/
 COPY child-device-systemd/config/tedge.toml /etc/tedge/

--- a/images/common/config/sudoers.d/step-ca
+++ b/images/common/config/sudoers.d/step-ca
@@ -1,0 +1,1 @@
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/step-ca-admin.sh, /usr/bin/step-ca, /usr/sbin/update-ca-certificates

--- a/images/common/utils/configure-device/runner.sh
+++ b/images/common/utils/configure-device/runner.sh
@@ -13,7 +13,8 @@ if [ $# -ge 2 ]; then
 fi
 
 _NEWLINE=$(printf '\n')
-find "$RUN_PARTS" -type f -name "$NAME_FILTER" -perm 755 | while IFS="$_NEWLINE" read -r file
+# Use -L to allow scripts to be a symlink, but this requires the results to be sorted afterwards
+find -L "$RUN_PARTS" -type f -name "$NAME_FILTER" -perm 755 | sort | while IFS="$_NEWLINE" read -r file
 do
     echo "Executing script: $file" >&2
     set +e

--- a/images/common/utils/configure-device/scripts.d/90_start-agent
+++ b/images/common/utils/configure-device/scripts.d/90_start-agent
@@ -2,4 +2,4 @@
 set -ex
 
 systemctl enable tedge-agent
-systemctl restart tedge-agent
+systemctl start tedge-agent

--- a/images/common/utils/enroll/enroll.sh
+++ b/images/common/utils/enroll/enroll.sh
@@ -37,7 +37,7 @@ fi
 has_feature() { echo "${FEATURES:-}" | grep -qw "$1"; }
 
 if ! has_feature "pki"; then
-    echo "Enrolling device without mtls" >&2
+    echo "Enrolling device without mtls. FEATURES=$FEATURES" >&2
     if [ -z "$TEDGE_MQTT_DEVICE_TOPIC_ID" ]; then
         TOPIC_ID="device/$(hostname)//"
         echo "Setting mqtt.device_topic_id based on hostname: $TOPIC_ID" >&2

--- a/images/common/utils/enroll/enroll.sh
+++ b/images/common/utils/enroll/enroll.sh
@@ -34,6 +34,20 @@ if [ "$INHERIT_ENV" = 1 ]; then
     . /etc/container.env
 fi
 
+has_feature() { echo "${FEATURES:-}" | grep -qw "$1"; }
+
+if ! has_feature "pki"; then
+    echo "Enrolling device without mtls" >&2
+    if [ -z "$TEDGE_MQTT_DEVICE_TOPIC_ID" ]; then
+        TOPIC_ID="device/$(hostname)//"
+        echo "Setting mqtt.device_topic_id based on hostname: $TOPIC_ID" >&2
+        tedge config set mqtt.device_topic_id "$TOPIC_ID"
+    fi
+    exit 0
+fi
+
+echo "Enrolling device with mtls (using a local PKI)" >&2
+
 
 PROVISION_PASSWORD="${PROVISION_PASSWORD:-}"
 PROVISION_PASSWORD_FILE=${PROVISION_PASSWORD_FILE:-/etc/provisioner_password}

--- a/images/common/utils/enroll/enroll.sh
+++ b/images/common/utils/enroll/enroll.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -e
+
+INHERIT_ENV=${INHERIT_ENV:-1}
+
+OLD_PWD="$(pwd)"
+cd /etc
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --inherit-env)
+            INHERIT_ENV=1
+            ;;
+        --no-inherit-env)
+            INHERIT_ENV=0
+            ;;
+        --provisioner-password-file)
+            PROVISION_PASSWORD_FILE="$2"
+            shift
+            ;;
+    esac
+    shift
+done
+
+if [ "$INHERIT_ENV" = 1 ]; then
+    # Create env file from PID 1
+    # (as this is the old service which inherits the container environment variables)
+    echo "Loading environment from PID 1"
+    tr '\0' '\n' </proc/1/environ \
+    | grep -v "^\(_\|HOME\|PATH\|TERM\|HOSTNAME\|PWD\|SHLVL\)=" | tee > /etc/container.env
+
+    # Load env
+    # shellcheck disable=SC1091
+    . /etc/container.env
+fi
+
+
+PROVISION_PASSWORD="${PROVISION_PASSWORD:-}"
+PROVISION_PASSWORD_FILE=${PROVISION_PASSWORD_FILE:-/etc/provisioner_password}
+if [ -n "$PROVISION_PASSWORD" ]; then
+    printf -- '%s' "$PROVISION_PASSWORD" > "$PROVISION_PASSWORD_FILE"
+    chmod 600 "$PROVISION_PASSWORD_FILE"
+fi
+
+enroll_device() {
+    # Enable downloading of root cert (this can be trusted when running in a controlled container env)
+    if [ -f "$PROVISION_PASSWORD_FILE" ]; then
+        /usr/bin/step-ca-admin.sh enroll "$(hostname)" \
+            --ca-url https://tedge:8443 \
+            --allow-insecure-root \
+            --provisioner-password-file "$PROVISION_PASSWORD_FILE"
+    else
+        /usr/bin/step-ca-admin.sh enroll "$(hostname)" \
+        --ca-url https://tedge:8443 \
+        --allow-insecure-root
+    fi
+}
+
+while :; do
+    if enroll_device; then
+        echo "Enrollment was successful"
+        exit 0
+    fi
+    sleep 2
+done
+
+# restore previous working directory
+cd "$OLD_PWD"

--- a/images/common/utils/init-pki/init-pki.sh
+++ b/images/common/utils/init-pki/init-pki.sh
@@ -16,4 +16,12 @@ set -a
 . /etc/container.env
 set +a
 
-step-ca-init.sh
+has_feature() { echo "${FEATURES:-}" | grep -qw "$1"; }
+
+if has_feature "pki"; then
+    echo "Initializing pki" >&2
+    step-ca-init.sh
+else
+    echo "The 'pki' feature is not enabled" >&2
+fi
+

--- a/images/common/utils/init-pki/init-pki.sh
+++ b/images/common/utils/init-pki/init-pki.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+#
+# Initialize the local pki
+#
+
+# Create env file from PID 1
+# (as this is the old service which inherits the container environment variables)
+echo "Loading environment from PID 1"
+tr '\0' '\n' </proc/1/environ \
+| grep -v "^\(_\|HOME\|PATH\|TERM\|HOSTNAME\|PWD\|SHLVL\)=" | tee > /etc/container.env
+
+# Load and export env
+set -a
+# shellcheck disable=SC1091
+. /etc/container.env
+set +a
+
+step-ca-init.sh

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - DEVICE_ID=${DEVICE_ID:-}
       - C8Y_BASEURL=${C8Y_BASEURL:-}
       - C8Y_USER=${C8Y_USER:-}
+      - FEATURES=${FEATURES:-"pki"}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - etc:/etc
@@ -44,6 +45,7 @@ services:
   child01:
     <<: *child-container
     environment:
+      - FEATURES=${FEATURES:-"pki"}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     hostname: child01
     volumes:
@@ -54,6 +56,7 @@ services:
     <<: *child-device-systemd
     hostname: child02
     environment:
+      - FEATURES=${FEATURES:-"pki"}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - child02_etc:/etc

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - DEVICE_ID=${DEVICE_ID:-}
       - C8Y_BASEURL=${C8Y_BASEURL:-}
       - C8Y_USER=${C8Y_USER:-}
-      - FEATURES=${FEATURES:-"pki"}
+      - FEATURES=${FEATURES:-pki}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - etc:/etc
@@ -45,7 +45,7 @@ services:
   child01:
     <<: *child-container
     environment:
-      - FEATURES=${FEATURES:-"pki"}
+      - FEATURES=${FEATURES:-pki}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     hostname: child01
     volumes:
@@ -56,7 +56,7 @@ services:
     <<: *child-device-systemd
     hostname: child02
     environment:
-      - FEATURES=${FEATURES:-"pki"}
+      - FEATURES=${FEATURES:-pki}
       - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - child02_etc:/etc

--- a/images/debian-systemd/docker-compose.yaml
+++ b/images/debian-systemd/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - DEVICE_ID=${DEVICE_ID:-}
       - C8Y_BASEURL=${C8Y_BASEURL:-}
       - C8Y_USER=${C8Y_USER:-}
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - etc:/etc
 
@@ -43,7 +44,7 @@ services:
   child01:
     <<: *child-container
     environment:
-      - TEDGE_MQTT_DEVICE_TOPIC_ID=device/child01//
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     hostname: child01
     volumes:
       - child01_etc:/etc
@@ -52,6 +53,8 @@ services:
   child02:
     <<: *child-device-systemd
     hostname: child02
+    environment:
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
     volumes:
       - child02_etc:/etc
       - child02_logs:/var/log/tedge


### PR DESCRIPTION
Configure mtls for secure communication between local components and clients.

The demo uses a community project, https://github.com/thin-edge/tedge-pki-smallstep, which uses [step-ca](https://github.com/smallstep/certificates) by [Smallstep](https://smallstep.com/certificates/index.html).

The PKI feature can be enabled or disabled by setting the following environment variable:

```sh
# Enable
FEATURES=pki
```

Or

```
# Disable
FEATURES=
```

The `FEATURES` variable will be used in the future for other optional features, and accepts a csv string, e.g. `FEATURES=feature1,feature2` etc.