### PR TITLE
feat(systemd): change default workdir and cleanup installation files

### DIFF
--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -48,7 +48,8 @@ COPY child-device-systemd/config/sshd_config /etc/ssh/sshd_config
 
 # Optional installations
 COPY common/optional-installer.sh .
-RUN ./optional-installer.sh
+RUN ./optional-installer.sh \
+    && rm optional-installer.sh
 
 # Device bootstrap (to run one-off commands on first boot)
 COPY common/utils/configure-device/runner.sh /usr/share/configure-device/

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -44,7 +44,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     && chmod +x /usr/sbin/policy-rc.d
 
 # Install base files to help with bootstrapping and common settings
-WORKDIR /setup
+WORKDIR /root
 COPY common/bootstrap.sh /usr/bin/bootstrap.sh
 
 # mqtt-logger
@@ -77,7 +77,8 @@ COPY common/config/sshd_config /etc/ssh/sshd_config
 
 # Optional installations
 COPY common/optional-installer.sh .
-RUN ./optional-installer.sh
+RUN ./optional-installer.sh \
+    && rm optional-installer.sh
 
 # Device bootstrap (to run one-off commands on first boot)
 COPY common/utils/configure-device/runner.sh /usr/share/configure-device/


### PR DESCRIPTION
Minor improvements to provide a more standard environment:

* Change default working directory to `/root` for systemd based images to allow users logging in via docker to be in the user's home directory
* Remove the optional-installer.sh script which is not needed in the final image