### PR TITLE
fix(systemd): publish firmware information with retain flag

### DIFF
--- a/images/common/utils/set-startup-info
+++ b/images/common/utils/set-startup-info
@@ -3,7 +3,7 @@ set -e
 TARGET="$(tedge config get mqtt.topic_root)/$(tedge config get mqtt.device_topic_id)"
 
 # firmware
-tedge mqtt pub --qos 1 "$TARGET/twin/firmware" "$(printf '{"name": "iot-linux", "version": "1.0.0"}')"
+tedge mqtt pub -r --qos 1 "$TARGET/twin/firmware" "$(printf '{"name": "iot-linux", "version": "1.0.0"}')"
 
 # Trigger inventory service on startup
 if command -V systemd; then

--- a/tests/debian-systemd/children-systemd/operations.robot
+++ b/tests/debian-systemd/children-systemd/operations.robot
@@ -7,6 +7,9 @@ Suite Setup    Set Child Device2
 
 *** Test Cases ***
 
+Firmware information should be shown on startup
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=1.0.0
+
 Install Firmware
     Cumulocity.Should Have Services    name=tedge-agent    status=up
     ${date_from}=    Get Test Start Time

--- a/tests/debian-systemd/main/operations.robot
+++ b/tests/debian-systemd/main/operations.robot
@@ -7,6 +7,18 @@ Suite Setup    Set Main Device
 
 *** Test Cases ***
 
+Firmware information should be shown on startup
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=1.0.0
+
+Install Firmware
+    Cumulocity.Should Have Services    name=tedge-agent    status=up
+    ${date_from}=    Get Test Start Time
+    Sleep    1s
+    ${binary_url}=    Cumulocity.Create Inventory Binary    iot-linux    child-firmware    contents=dummy_file
+    ${operation}=    Cumulocity.Install Firmware    name=iot-linux    version=2.0.0    url=${binary_url}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=90
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=2.0.0    c8y_Firmware.url\=${binary_url}
+
 Restart device
     ${date_from}=    Get Test Start Time
     Sleep    1s


### PR DESCRIPTION
Fix a bug where the firmware information was not being published as a retained MQTT message which resulted in the message being missed if the mapper was not yet started.

Adding system tests to cover this functionality.