### PR TITLE
feat(systemd): add default tedge-log-plugin file to child device container

### DIFF
--- a/images/child-device-container/child.dockerfile
+++ b/images/child-device-container/child.dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
 
 USER tedge
 COPY child-device-container/config/tedge-configuration-plugin.toml /etc/tedge/plugins/
+COPY child-device-container/config/tedge-log-plugin.toml /etc/tedge/plugins/
 COPY common/utils/enroll/enroll.sh /usr/bin/
 COPY child-device-container/entrypoint.sh /app/
 COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/


### PR DESCRIPTION
Add a default tedge-log-plugin with more log files configured to better show-case the functionality