### PR TITLE
ci: build the entire compose project before starting it to avoid race conditions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,6 +105,7 @@ jobs:
         run: |
           case "${{matrix.job.bootstrap}}" in
               script)
+                  just IMAGE=${{matrix.job.target}} prepare-up
                   just IMAGE=${{matrix.job.target}} up
                   just IMAGE=${{matrix.job.target}} bootstrap --no-prompt
                   ;;
@@ -125,6 +126,7 @@ jobs:
                   ;;
 
               *)
+                  just IMAGE=${{matrix.job.target}} prepare-up
                   just IMAGE=${{matrix.job.target}} up
                   echo "Skipping bootstrapping"
                   ;;


### PR DESCRIPTION
Try to reduce irregularities during system tests by building first and then starting everything up, otherwise the containers can startup at wildly different times.