### PR TITLE
ci: streamline test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,6 @@ on:
   # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
   pull_request_target:
     branches: [ main ]
-  push:
-    branches: [ main ]
   merge_group:
 jobs:
   approve:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,7 @@ jobs:
           case "${{matrix.job.bootstrap}}" in
               script)
                   just IMAGE=${{matrix.job.target}} prepare-up
-                  just IMAGE=${{matrix.job.target}} up
+                  just IMAGE=${{matrix.job.target}} up --build=false
                   just IMAGE=${{matrix.job.target}} bootstrap --no-prompt
                   ;;
 
@@ -125,7 +125,7 @@ jobs:
 
               *)
                   just IMAGE=${{matrix.job.target}} prepare-up
-                  just IMAGE=${{matrix.job.target}} up
+                  just IMAGE=${{matrix.job.target}} up --build=false
                   echo "Skipping bootstrapping"
                   ;;
           esac

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,15 +43,11 @@ jobs:
 
     steps:
       # Checkout either the PR or the branch
-      - name: Checkout PR
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR. Only after the manual approval process
-
       - name: Checkout
         uses: actions/checkout@v4
-        if: ${{ github.event_name != 'pull_request_target' }}
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          fetch-depth: 0
 
       - uses: reubenmiller/setup-go-c8y-cli@main
       - name: install c8y-tedge extension

--- a/images/alpine-s6/bootstrap.sh
+++ b/images/alpine-s6/bootstrap.sh
@@ -1,44 +1,5 @@
 #!/bin/sh
 set -e
-
-SHOULD_PROMPT=${SHOULD_PROMPT:-1}
-CAN_PROMPT=0
-
-#
-# Detect if the shell is running in interactive mode or not
-if [ -t 0 ]; then
-    CAN_PROMPT=1
-else
-    CAN_PROMPT=0
-fi
-
-prompt_value() {
-    user_text="$1"
-    value="$2"
-
-    if [ "$SHOULD_PROMPT" = 1 ] && [ "$CAN_PROMPT" = 1 ]; then
-        printf "\n%s (%s): " "$user_text" "${value:-not set}" >&2
-        read -r user_input
-        if [ -n "$user_input" ]; then
-            value="$user_input"
-        fi
-    fi
-    echo "$value"
-}
-
 if [ -z "$TEDGE_MQTT_DEVICE_TOPIC_ID" ]; then
-    if [ -z "$C8Y_USER" ]; then
-        C8Y_USER=$(prompt_value "Enter your Cumulocity IoT user" "$C8Y_USER")
-    fi
-
-    if [ -z "$C8Y_USER" ]; then
-        echo "C8Y_USER is not set"
-        exit 1
-    fi
-
-    if [ -n "$C8Y_PASSWORD" ]; then
-        C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
-    else
-        tedge cert upload c8y --user "$C8Y_USER"
-    fi
+    tedge cert upload c8y
 fi

--- a/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
+++ b/images/alpine-s6/mosquitto/mosquitto-entrypoint.sh
@@ -20,7 +20,7 @@ fi
 #
 # Upload cert if credentials are available
 if [ -n "$C8Y_PASSWORD" ] && [ -n "$C8Y_USER" ]; then
-    env C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER" ||:
+    tedge cert upload c8y --user "$C8Y_USER" ||:
 fi
 
 # Wait until the device has been registered before starting the bridge,

--- a/images/common/bootstrap.sh
+++ b/images/common/bootstrap.sh
@@ -332,19 +332,8 @@ bootstrap_c8y() {
     echo "Setting c8y.url to $C8Y_BASEURL"
     sudo tedge config set c8y.url "$C8Y_BASEURL"
 
-    C8Y_USER=$(prompt_value "Enter your Cumulocity user" "$C8Y_USER")
-
-    if [ -n "$C8Y_USER" ]; then
-        echo "Uploading certificate to Cumulocity using tedge"
-        if [ -n "$C8Y_PASSWORD" ]; then
-            C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
-        else
-            echo ""
-            tedge cert upload c8y --user "$C8Y_USER"
-        fi
-    else
-        fail "When manually bootstrapping you have to upload the certificate again as the device certificate is recreated"
-    fi
+    echo "Uploading certificate to Cumulocity using tedge"
+    tedge cert upload c8y
 
     # Grace period for the server to process the certificate
     # but it is not critical for the connection, as the connection


### PR DESCRIPTION
Improve the workflow and surrounding actions like bootstrapping:
* Stop running test twice for the same commit (merge_group and when the merge_group is committed to main)
* Stop trying to build the compose image after using the prepare
* Refactor bootstrap logic to use tedge to prompt for missing information