### PR TITLE
refactor: remove workaround which started two started ssh and tedge-container-monitor

### DIFF
--- a/images/common/config/bootstrap/post.d/10-start-services.sh
+++ b/images/common/config/bootstrap/post.d/10-start-services.sh
@@ -19,8 +19,6 @@ control_service() {
 }
 
 sleep 5
-control_service tedge-container-monitor start
-control_service ssh start
 
 # Restart collectd as sometimes it fail with the error:
 # mqtt plugin: mosquitto_connect failed: Cannot assign requested address


### PR DESCRIPTION
Removing workarounds which are no longer required