### PR TITLE
feat(systemd): publish agent information on child devices

### DIFF
--- a/images/child-device-container/child.dockerfile
+++ b/images/child-device-container/child.dockerfile
@@ -30,6 +30,11 @@ COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/
 COPY common/utils/configure-device/runner.sh /usr/share/configure-device/
 COPY common/utils/set-startup-info /usr/share/configure-device/scripts.d/90_set-startup-info
 
+# Inventory scripts
+# FIXME: tedge should support this out of the box, but currently the c8y_Agent fragment
+# is published by the mapper and not the tedge-agent, so it needs a mapping rule.
+COPY common/utils/set-agent-info /usr/share/tedge-inventory/scripts.d/50_c8y_Agent
+
 ENV TEDGE_MQTT_CLIENT_HOST=tedge
 ENV TEDGE_HTTP_CLIENT_HOST=tedge
 ENV TEDGE_C8Y_PROXY_CLIENT_HOST=tedge

--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -63,6 +63,11 @@ COPY common/utils/enroll/enroll.sh /usr/bin/
 RUN ln -sf /usr/bin/enroll.sh /usr/share/configure-device/scripts.d/70_enroll
 COPY common/utils/set-startup-info /usr/share/configure-device/scripts.d/90_set-startup-info
 
+# Inventory scripts
+# FIXME: tedge should support this out of the box, but currently the c8y_Agent fragment
+# is published by the mapper and not the tedge-agent, so it needs a mapping rule.
+COPY common/utils/set-agent-info /usr/share/tedge-inventory/scripts.d/50_c8y_Agent
+
 COPY child-device-systemd/config/system.toml /etc/tedge/
 COPY child-device-systemd/config/tedge.toml /etc/tedge/
 COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/

--- a/images/common/utils/set-agent-info
+++ b/images/common/utils/set-agent-info
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+TEDGE_VERSION="$(tedge --version | cut -d' ' -f2- ||:)"
+printf 'name="%s"\n' "thin-edge.io"
+printf 'url="%s"\n' "https://thin-edge.io"
+printf 'version="%s"\n' "${TEDGE_VERSION:-unknown}"

--- a/tests/debian-systemd/children-container/telemetry.robot
+++ b/tests/debian-systemd/children-container/telemetry.robot
@@ -14,3 +14,10 @@ Sends measurements
     Skip    Container does not publish measurements by default
     ${date_from}=    Get Test Start Time
     Cumulocity.Device Should Have Measurements    minimum=2    after=${date_from}    timeout=30
+
+Agent information
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Agent
+    Log    ${mo["c8y_Agent"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["name"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["version"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["url"]}

--- a/tests/debian-systemd/children-systemd/telemetry.robot
+++ b/tests/debian-systemd/children-systemd/telemetry.robot
@@ -14,3 +14,10 @@ Sends measurements
     Skip    Container does not publish measurements by default
     ${date_from}=    Get Test Start Time
     Cumulocity.Device Should Have Measurements    minimum=2    after=${date_from}    timeout=30
+
+Agent information
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Agent
+    Log    ${mo["c8y_Agent"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["name"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["version"]}
+    Should Not Be Empty    ${mo["c8y_Agent"]["url"]}


### PR DESCRIPTION
Support publishing agent information including the version to make it easier to debug/track