### PR TITLE
fix: device profile firmware interaction

### DIFF
--- a/images/child-device-container/config/tedge-log-plugin.toml
+++ b/images/child-device-container/config/tedge-log-plugin.toml
@@ -1,4 +1,8 @@
 [[files]]
+type = "device_profile"
+path = "/var/log/tedge/agent/workflow-device_profile-*"
+
+[[files]]
 type = "software-management"
 path = "/var/log/tedge/agent/workflow-software*"
 

--- a/images/child-device-systemd/config/tedge-log-plugin.toml
+++ b/images/child-device-systemd/config/tedge-log-plugin.toml
@@ -1,4 +1,8 @@
 [[files]]
+type = "device_profile"
+path = "/var/log/tedge/agent/workflow-device_profile-*"
+
+[[files]]
 type = "software-management"
 path = "/var/log/tedge/agent/workflow-software*"
 

--- a/images/common/config/tedge-log-plugin.toml
+++ b/images/common/config/tedge-log-plugin.toml
@@ -1,6 +1,22 @@
 [[files]]
+type = "device_profile"
+path = "/var/log/tedge/agent/workflow-device_profile-*"
+
+[[files]]
 type = "software-management"
 path = "/var/log/tedge/agent/workflow-software*"
+
+[[files]]
+type = "firmware_update"
+path = "/var/log/tedge/agent/workflow-firmware_update-*"
+
+[[files]]
+type = "restart"
+path = "/var/log/tedge/agent/workflow-restart-*"
+
+[[files]]
+type = "all-workflows"
+path = "/var/log/tedge/agent/workflow-*"
 
 [[files]]
 type = "shell"

--- a/images/common/utils/workflows/firmware_update.toml
+++ b/images/common/utils/workflows/firmware_update.toml
@@ -42,6 +42,11 @@ on_error = { status = "failed", reason = "fail to restart"}
 
 [commit]
 script = "sleep 1"
+on_success = "publish"
+on_error = "failed"
+
+[publish]
+script = "tedge mqtt pub --retain --qos 1 ${.topic.root_prefix}/${.topic.target}/twin/firmware '{\"name\":\"${.payload.name}\",\"version\":\"${.payload.version}\",\"url\":\"${.payload.url}\"}'"
 on_success = "successful"
 on_error = "failed"
 

--- a/tests/debian-systemd/children-container/operations.robot
+++ b/tests/debian-systemd/children-container/operations.robot
@@ -32,3 +32,43 @@ Install software package
     ${operation}=    Cumulocity.Install Software    {"name": "jq", "version": "latest", "softwareType": "apk"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=90
     Cumulocity.Device Should Have Installed Software    jq
+
+Install device profile
+    ${config_url}=    Create Inventory Binary
+    ...    tedge-configuration-plugin
+    ...    tedge-configuration-plugin
+    ...    file=${CURDIR}/../tedge-configuration-plugin.toml
+
+    ${PROFILE_NAME}=    Set Variable    Test Profile
+    ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n    {
+    ...      "firmware": {
+    ...        "name":"iot-linux",
+    ...        "version":"3.0.0",
+    ...        "url":"https://abc.com/some/firmware/url"
+    ...      },
+    ...      "software":[
+    ...        {
+    ...          "name":"jq",
+    ...          "action":"install",
+    ...          "version":"latest",
+    ...          "url":""
+    ...        }
+    ...      ],
+    ...      "configuration":[
+    ...        {
+    ...          "name":"tedge-configuration-plugin",
+    ...          "type":"tedge-configuration-plugin",
+    ...          "url":"${config_url}"
+    ...        }
+    ...      ]
+    ...    }
+
+    ${profile}=    Cumulocity.Create Device Profile    ${PROFILE_NAME}    ${PROFILE_PAYLOAD}
+    ${operation}=    Cumulocity.Install Device Profile    ${profile["id"]}
+    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Have Device Profile Installed    ${profile["id"]}
+
+    # Check meta information
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=3.0.0
+    Cumulocity.Device Should Have Installed Software    {"name":"jq"}
+    Cumulocity.Should Support Configurations    container.env    includes=${True}

--- a/tests/debian-systemd/children-systemd/operations.robot
+++ b/tests/debian-systemd/children-systemd/operations.robot
@@ -35,3 +35,43 @@ Install software package
 
     # lib* packages should be excluded by default due to the custom tedge.toml config
     Cumulocity.Device Should Not Have Installed Software    libc-bin
+
+Install device profile
+    ${config_url}=    Create Inventory Binary
+    ...    tedge-configuration-plugin
+    ...    tedge-configuration-plugin
+    ...    file=${CURDIR}/../tedge-configuration-plugin.toml
+
+    ${PROFILE_NAME}=    Set Variable    Test Profile
+    ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n    {
+    ...      "firmware": {
+    ...        "name":"iot-linux",
+    ...        "version":"3.0.0",
+    ...        "url":"https://abc.com/some/firmware/url"
+    ...      },
+    ...      "software":[
+    ...        {
+    ...          "name":"jq",
+    ...          "action":"install",
+    ...          "version":"latest",
+    ...          "url":""
+    ...        }
+    ...      ],
+    ...      "configuration":[
+    ...        {
+    ...          "name":"tedge-configuration-plugin",
+    ...          "type":"tedge-configuration-plugin",
+    ...          "url":"${config_url}"
+    ...        }
+    ...      ]
+    ...    }
+
+    ${profile}=    Cumulocity.Create Device Profile    ${PROFILE_NAME}    ${PROFILE_PAYLOAD}
+    ${operation}=    Cumulocity.Install Device Profile    ${profile["id"]}
+    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Have Device Profile Installed    ${profile["id"]}
+
+    # Check meta information
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=3.0.0
+    Cumulocity.Device Should Have Installed Software    {"name":"jq"}
+    Cumulocity.Should Support Configurations    container.env    includes=${True}

--- a/tests/debian-systemd/main/operations.robot
+++ b/tests/debian-systemd/main/operations.robot
@@ -51,6 +51,46 @@ Get Logfile Request
     apt-terminal-log
     dpkg
 
+Install device profile
+    ${config_url}=    Create Inventory Binary
+    ...    tedge-configuration-plugin
+    ...    tedge-configuration-plugin
+    ...    file=${CURDIR}/../tedge-configuration-plugin.toml
+
+    ${PROFILE_NAME}=    Set Variable    Test Profile
+    ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n    {
+    ...      "firmware": {
+    ...        "name":"iot-linux",
+    ...        "version":"3.0.0",
+    ...        "url":"https://abc.com/some/firmware/url"
+    ...      },
+    ...      "software":[
+    ...        {
+    ...          "name":"jq",
+    ...          "action":"install",
+    ...          "version":"latest",
+    ...          "url":""
+    ...        }
+    ...      ],
+    ...      "configuration":[
+    ...        {
+    ...          "name":"tedge-configuration-plugin",
+    ...          "type":"tedge-configuration-plugin",
+    ...          "url":"${config_url}"
+    ...        }
+    ...      ]
+    ...    }
+
+    ${profile}=    Cumulocity.Create Device Profile    ${PROFILE_NAME}    ${PROFILE_PAYLOAD}
+    ${operation}=    Cumulocity.Install Device Profile    ${profile["id"]}
+    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Have Device Profile Installed    ${profile["id"]}
+
+    # Check meta information
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=3.0.0
+    Cumulocity.Device Should Have Installed Software    {"name":"jq"}
+    Cumulocity.Should Support Configurations    container.env    includes=${True}
+
 *** Keywords ***
 
 Get Logfile Request

--- a/tests/debian-systemd/tedge-configuration-plugin.toml
+++ b/tests/debian-systemd/tedge-configuration-plugin.toml
@@ -1,0 +1,34 @@
+[[files]]
+path = "/etc/tedge/tedge.toml"
+type = "tedge.toml"
+user = "tedge"
+group = "tedge"
+mode = 0o444
+
+[[files]]
+path = "/etc/tedge/system.toml"
+type = "system.toml"
+user = "tedge"
+group = "tedge"
+mode = 0o444
+
+[[files]]
+path = "/etc/modem.json"
+type = "modem"
+user = "tedge"
+group = "tedge"
+mode = 0o444
+
+[[files]]
+path = '/etc/tedge/plugins/tedge-log-plugin.toml'
+type = 'tedge-log-plugin'
+user = 'tedge'
+group = 'tedge'
+mode = 0o644
+
+[[files]]
+path = '/etc/container.env'
+type = 'container.env'
+user = 'root'
+group = 'root'
+mode = 0o644

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.31.3
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.37.2
 robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0


### PR DESCRIPTION
Manually publish the new firmware name/version because when installing firmware via a device profile, the name/version isn't updated.