### PR TITLE
release(systemd): update default demo docker compose file to use new systemd tedge-agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ The following features are covered by the demo.
 
 **Main device**
 
+* [x] Availability Monitoring
 * [x] Configuration management
 * [x] mqtt-logger (to better understand what messages are going in and out)
 * [x] Device reboot
-* [x] Events
-    * [x] On boot-up service: sends an event on startup
+* [x] Device Profile
+* [x] Firmware Update (simulated)
 * [x] Log management
     * [x] log files
-* [x] Measurements (via collectd)
 * [x] Remote Access
     * [x] SSH
 * [x] Services
@@ -134,15 +134,24 @@ The following features are covered by the demo.
     * [x] apt
     * [x] container (docker, docker-compose)
 * [x] Telemetry
-    * [x] Collectd
+    * [x] Measurements (via collectd)
+    * [x] Events
+        * [x] On boot-up service: sends an event on startup
 
 **Child devices**
 
+* [x] Availability Monitoring
 * [x] Configuration management
-* [x] Firmware management
-    * [x] Sending events before and after the operation transition are being delayed and sent at once
-* [x] Measurements
+* [x] Device reboot
+* [x] Device Profile
+* [x] Firmware Update (simulated)
+* [x] Log management
+    * [x] log files
 * [x] Services
+    * [x] tedge services
+* [x] Software management
+    * [x] apk (Alpine based image)
+    * [x] apt (Debian based image)
 
 ## Known issues
 

--- a/demos/docker-compose/device/docker-compose.yaml
+++ b/demos/docker-compose/device/docker-compose.yaml
@@ -1,8 +1,18 @@
-# child device template
-x-child-defaults: &child-defaults
-  image: ghcr.io/thin-edge/tedge-demo-child:${VERSION:-latest}
+# child device templates
+x-child-agent: &child-container
+  image: ghcr.io/thin-edge/tedge-demo-child-container:${VERSION:-latest}
   pull_policy: always
   restart: always
+  tmpfs:
+    - /tmp
+  networks:
+    - tedge
+
+x-child-defaults: &child-device-systemd
+  image: ghcr.io/thin-edge/tedge-demo-child-systemd:${VERSION:-latest}
+  pull_policy: always
+  restart: always
+  privileged: true
   networks:
     - tedge
 
@@ -12,34 +22,45 @@ services:
     image: ghcr.io/thin-edge/tedge-demo-main-systemd:${VERSION:-latest}
     pull_policy: always
     volumes:
-      - etc:/etc
+      - main_etc:/etc
       # Enable docker from docker - But then this container has elevated access to system resources!
       - /var/run/docker.sock:${DOCKER_SOCKET:-/var/run/docker.sock}:rw
     restart: always
-    tmpfs:
-      - /run
-      - /tmp
     privileged: true
     environment:
-      - DEVICE_ID=${DEVICE_ID:-}
-      - C8Y_BASEURL=${C8Y_BASEURL:-}
-      - C8Y_USER=${C8Y_USER:-}
+      - FEATURES=${FEATURES:-pki}
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
+    hostname: tedge
     networks:
       - tedge
 
   # child devices
   child01:
-    <<: *child-defaults
+    <<: *child-container
     environment:
-      - CONNECTOR_DEVICE_ID=child01
+      - FEATURES=${FEATURES:-pki}
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
+    hostname: child01
+    volumes:
+      - child01_etc:/etc
+      - child01_logs:/var/log/tedge
 
   child02:
-    <<: *child-defaults
+    <<: *child-device-systemd
+    hostname: child02
     environment:
-      - CONNECTOR_DEVICE_ID=child02
+      - FEATURES=${FEATURES:-pki}
+      - PROVISION_PASSWORD=${PROVISION_PASSWORD:-dummy}
+    volumes:
+      - child02_etc:/etc
+      - child02_logs:/var/log/tedge
 
 volumes:
-  etc:
+  main_etc:
+  child01_etc:
+  child01_logs:
+  child02_etc:
+  child02_logs:
 
 networks:
   tedge:


### PR DESCRIPTION
Update the docker compose used by `c8y tedge demo start` to use the latest demo setup with extended features:

* Use tedge-agent as child device (both in systemd and single process container configurations)
* Enable device profile support
* Add firmware update workflow