### PR TITLE
feat: add mosquitto listener for container network

### DIFF
--- a/images/common/config/mosquitto-conf/tedge-networkcontainer.conf
+++ b/images/common/config/mosquitto-conf/tedge-networkcontainer.conf
@@ -1,0 +1,3 @@
+listener 1884 0.0.0.0
+allow_anonymous true
+require_certificate false

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -40,7 +40,7 @@ configure_users() {
     usermod -a -G adm tedge ||:
 
     if [ ! -f /etc/sudoers.d/tedge ]; then
-        sudo sh -c "echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /bin/systemctl, /bin/journalctl, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge"
+        sudo sh -c "echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /bin/systemctl, /bin/journalctl, /sbin/shutdown, /usr/bin/on_shutdown.sh, /usr/bin/tedge-container' > /etc/sudoers.d/tedge"
     fi
 }
 

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -15,8 +15,7 @@ install_container_management () {
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
         podman \
         podman-compose \
-        tedge-container-plugin-ng \
-        unzip
+        tedge-container-plugin-ng
 
     # create systemd-tmpfiles config to create a symlink for docker to the podman socket
     # which allows using docker and docker compose without having to set the DOCKER_HOST variable

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -114,6 +114,7 @@ COPY common/config/collectd.conf.d /etc/collectd/collectd.conf.d
 
 # Custom mosquitto config
 COPY common/config/mosquitto.conf /etc/mosquitto/conf.d/
+COPY common/config/mosquitto-conf/tedge-networkcontainer.conf /etc/tedge/mosquitto-conf/
 
 # sudoers
 COPY common/config/sudoers.d/* /etc/sudoers.d/


### PR DESCRIPTION
Add an additional mosquitto listener on port 1884 which can be used by containers to read and publish data.