### PR TITLE
feat: add tedge-nodered-plugin-ng

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -74,6 +74,7 @@ RUN echo "running" \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         tedge-inventory-plugin \
         c8y-command-plugin \
+        tedge-nodered-plugin-ng \
         # Local PKI service for easy child device registration
         tedge-pki-smallstep-ca \
     && systemctl disable c8y-firmware-plugin.service \


### PR DESCRIPTION
Support deploying nodered flow using [tedge-nodered-plugin-ng](https://github.com/thin-edge/tedge-nodered-plugin/tree/next) which can manage both node-red projects or nodered-flows