### PR TITLE
feat: use new tedge-command-plugin

### DIFF
--- a/images/alpine-s6/alpine-s6.dockerfile
+++ b/images/alpine-s6/alpine-s6.dockerfile
@@ -32,7 +32,7 @@ RUN curl -sSL thin-edge.io/install.sh | sh -s
 RUN curl -sSL thin-edge.io/install-services.sh | sh -s \
     # Install additional community plugins
     && apk add --no-cache \
-        c8y-command-plugin \
+        tedge-command-plugin \
         tedge-apk-plugin
 
 # Set permissions of all files under /etc/tedge

--- a/images/common/config/tedge-configuration-plugin.toml
+++ b/images/common/config/tedge-configuration-plugin.toml
@@ -34,7 +34,7 @@ group = 'root'
 mode = 0o644
 
 [[files]]
-path = '/etc/c8y-command-plugin/env'
+path = '/etc/tedge-command-plugin/env'
 type = 'shell'
 user = 'tedge'
 group = 'tedge'

--- a/images/common/utils/set-startup-info
+++ b/images/common/utils/set-startup-info
@@ -3,6 +3,8 @@ set -e
 TARGET="$(tedge config get mqtt.topic_root)/$(tedge config get mqtt.device_topic_id)"
 
 # firmware
+# TODO: Remove dumb sleep and find out way the firmware is not always published to the cloud
+sleep 5
 tedge mqtt pub -r --qos 1 "$TARGET/twin/firmware" "$(printf '{"name": "iot-linux", "version": "1.0.0"}')"
 
 # Trigger inventory service on startup

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -73,7 +73,7 @@ RUN echo "running" \
     && systemctl enable collectd \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         tedge-inventory-plugin \
-        c8y-command-plugin \
+        tedge-command-plugin \
         tedge-nodered-plugin-ng \
         # Local PKI service for easy child device registration
         tedge-pki-smallstep-ca \

--- a/images/tedge-containermgmt/Dockerfile
+++ b/images/tedge-containermgmt/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
-        c8y-command-plugin \
+        tedge-command-plugin \
         tedge-apk-plugin \
         # Containerization defaults
         tedge-container-plugin \

--- a/images/tedge/Dockerfile
+++ b/images/tedge/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/rsa.B24635C28003430C.key' > /etc/apk/keys/community@thinedge-B24635C28003430C.rsa.pub \
     && wget -q -O - 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
-        c8y-command-plugin \
+        tedge-command-plugin \
         tedge-apk-plugin \
     && apk cache clean
 

--- a/tests/alpine-s6/children/operations.robot
+++ b/tests/alpine-s6/children/operations.robot
@@ -34,14 +34,14 @@ It Should List the Installed Software
     Device Should Have Installed Software    tedge    tedge-agent
 
 Install software (apk package)
-    ${operation}=    Install Software    {"name": "jq", "version": "latest", "softwareType": "apk"}
+    ${operation}=    Install Software    {"name": "htop", "version": "latest", "softwareType": "apk"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Device Should Have Installed Software    {"name": "jq", "softwareType": "apk"}
+    Device Should Have Installed Software    {"name": "htop", "softwareType": "apk"}
 
 Uninstall software (apk package)
-    ${operation}=     Uninstall Software    {"name": "jq", "version": "latest", "softwareType": "apk"}
+    ${operation}=     Uninstall Software    {"name": "htop", "version": "latest", "softwareType": "apk"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Device Should Not Have Installed Software    {"name": "jq", "softwareType": "apk"}
+    Device Should Not Have Installed Software    {"name": "htop", "softwareType": "apk"}
 
 *** Keywords ***
 

--- a/tests/tedge/operations.robot
+++ b/tests/tedge/operations.robot
@@ -98,16 +98,16 @@ Check Software List
 Install software
     [Arguments]    ${device}
     Cumulocity.Set Device    ${device}
-    ${operation}=    Cumulocity.Install Software    {"name": "jq", "version": "latest", "softwareType": "apk"}
+    ${operation}=    Cumulocity.Install Software    {"name": "htop", "version": "latest", "softwareType": "apk"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Device Should Have Installed Software    jq
+    Device Should Have Installed Software    htop
 
 Uninstall software
     [Arguments]    ${device}
     Cumulocity.Set Device    ${device}
-    ${operation}=     Cumulocity.Uninstall Software    {"name": "jq", "version": "latest", "softwareType": "apk"}
+    ${operation}=     Cumulocity.Uninstall Software    {"name": "htop", "version": "latest", "softwareType": "apk"}
     Operation Should Be SUCCESSFUL    ${operation}
-    Device Should Not Have Installed Software    jq
+    Device Should Not Have Installed Software    htop
 
 Execute shell command
     [Arguments]    ${device}


### PR DESCRIPTION
Use new generic tedge-command-plugin which uses a new thin-edge.io 1.4.0 feature which allows custom operation handlers to use thin-edge.io workflows.