### PR TITLE
feat: add tedge-command-plugin to child device images

### DIFF
--- a/images/child-device-container/child.dockerfile
+++ b/images/child-device-container/child.dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache \
     && curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/config.alpine.txt?distro=alpine&codename=v3.8' >> /etc/apk/repositories \
     && apk add --no-cache \
         tedge-apk-plugin \
+        tedge-command-plugin \
         tedge-inventory-plugin \
         tedge-pki-smallstep-client \
     && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /bin/kill" > /etc/sudoers.d/tedge \

--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -36,6 +36,7 @@ RUN echo "running" \
     && curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/setup.deb.sh' | sudo -E bash \
     && DEBIAN_FRONTEND=noninteractive apt-get -y install \
         tedge-agent \
+        tedge-command-plugin \
         tedge-inventory-plugin \
         # Local PKI service for easy child device registration
         tedge-pki-smallstep-client \

--- a/tests/debian-systemd/children-container/operations.robot
+++ b/tests/debian-systemd/children-container/operations.robot
@@ -72,3 +72,8 @@ Install device profile
     Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=3.0.0
     Cumulocity.Device Should Have Installed Software    {"name":"jq"}
     Cumulocity.Should Support Configurations    container.env    includes=${True}
+
+Execute shell command
+    ${operation}=    Cumulocity.Execute Shell Command    ls -l /etc/tedge
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
+    Should Not Be Empty    ${operation["c8y_Command"]["result"]}

--- a/tests/debian-systemd/children-systemd/operations.robot
+++ b/tests/debian-systemd/children-systemd/operations.robot
@@ -75,3 +75,8 @@ Install device profile
     Cumulocity.Managed Object Should Have Fragment Values    c8y_Firmware.name\=iot-linux    c8y_Firmware.version\=3.0.0
     Cumulocity.Device Should Have Installed Software    {"name":"jq"}
     Cumulocity.Should Support Configurations    container.env    includes=${True}
+
+Execute shell command
+    ${operation}=    Cumulocity.Execute Shell Command    ls -l /etc/tedge
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
+    Should Not Be Empty    ${operation["c8y_Command"]["result"]}


### PR DESCRIPTION
Install tedge-command-plugin on the child device images to show-off the new workflow based operation handler.