### PR TITLE
fix(collectd): only monitor disk usage of rootfs and overlay partitions

### DIFF
--- a/images/common/config/collectd.conf
+++ b/images/common/config/collectd.conf
@@ -484,28 +484,8 @@ LoadPlugin mqtt
 #</Plugin>
 
 <Plugin df>
-#	Device "/dev/sda1"
-#	Device "192.168.0.2:/mnt/nfs"
-#	MountPoint "/home"
-#	FSType "ext3"
-
-	IgnoreSelected true	#Ignore the partitions with the file system types (FSType) listed below
-	# ignore rootfs; else, the root file-system would appear twice, causing
-	# one of the updates to fail and spam the log
 	FSType rootfs
-	# ignore the usual virtual / temporary file-systems
-	FSType sysfs
-	FSType proc
-	FSType devtmpfs
-	FSType devpts
-	FSType tmpfs
-	FSType fusectl
-	FSType cgroup
-	FSType vfat	# File system type of boot partition
-	FSType squashfs	# File system type of snap partitions
-
-#	ReportByDevice false
-#	ReportInodes false
+	FSType overlay
 
 	ValuesAbsolute false
 	ValuesPercentage true


### PR DESCRIPTION
Previously collectd was also monitoring files which are mounted within the container, e.g. `/etc/resolv.conf` which was causing an issue in Cumulocity as the measurement name had a "." in it.

Below shows an example of the Cumulocity error presented to the user:

![image](https://github.com/user-attachments/assets/1a10eae0-2823-4b46-aaf6-e15463f0f693)
