### PR TITLE
feat: add tedge-monit-setup package to demo

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -74,6 +74,7 @@ RUN echo "running" \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         tedge-inventory-plugin \
         tedge-command-plugin \
+        tedge-monit-setup \
         tedge-nodered-plugin-ng \
         # Local PKI service for easy child device registration
         tedge-pki-smallstep-ca \


### PR DESCRIPTION
Add tedge-monit-setup package which installs monit along with some thin-edge.io releated monitoring rules.

monit includes a http service endpoint which can then be used to demonstrate the [cumulocity-remote-access-cloud-http-proxy](https://github.com/Cumulocity-IoT/cumulocity-remote-access-cloud-http-proxy) functionality.

Resolves https://github.com/thin-edge/tedge-demo-container/issues/129