### PR TITLE
fix: increase mosquitto default inflight message limit

### DIFF
--- a/images/common/config/mosquitto.conf
+++ b/images/common/config/mosquitto.conf
@@ -1,2 +1,6 @@
 log_dest syslog
 log_type debug
+
+# increase default size (which is 20) to avoid problems where messages can be
+# silently dropped
+max_inflight_messages 200


### PR DESCRIPTION
Prevent messages from being dropped due to the max inflight message limit of mosquitto being limit being exceeded.