### PR TITLE
fix(init): only restart service if it is enabled

### DIFF
--- a/images/common/config/bootstrap/post.d/10-start-services.sh
+++ b/images/common/config/bootstrap/post.d/10-start-services.sh
@@ -9,10 +9,8 @@ control_service() {
     name="$1"
     action="$2"
     if command -v systemctl >/dev/null 2>&1; then
-        echo "Enable/$action $name"
-        sudo systemctl enable "$name"
-
-        if [ -d /run/systemd/system ]; then
+        echo "$action $name"
+        if [ -d /run/systemd/system ] && systemctl -q is-enabled "$name"; then
             sudo systemctl "$action" "$name"
         fi
     fi


### PR DESCRIPTION
During the running of the 10-start-services.sh which is called on the post bootstrap hooks, only run the service actions if the service is enabled.

This enables users to disable the starting of the service by using `systemctl disable <name>` if they using the demo container as a base image and wanting to customize its behaviour.