### PR TITLE
feat: enable tedge tab completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Once you have [just](https://github.com/casey/just) installed, you can proceed w
 
     You will be prompted for the required details. You can hit `<enter>` to accept the default values. The default values are provided via the `.env` file from the first step.
 
+    Alternatively, if you're a [go-c8y-cli](https://goc8ycli.netlify.app/) user, and have the [c8y-tedge](https://github.com/thin-edge/c8y-tedge) extension installed, then you can bootstrap the device using:
+
+    ```sh
+    just bootstrap-c8y
+    ```
+
 4. Click on the device link shown on your console
 
 5. That's it 🚀

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -56,8 +56,42 @@ configure_services() {
     fi
 }
 
+set_zsh_defaults() {
+    cat <<EOT >> "$1"
+autoload -U compinit; compinit
+# zsh styling to make the completion menu easier to read and use
+zstyle ':completion:*' menu select
+# bind shift+tab to reverse menu complete
+zmodload zsh/complist
+bindkey -M menuselect '^[[Z' reverse-menu-complete
+EOT
+}
+
+configure_shells() {    
+    # Enable tab completions (note: fish does not require any changes)
+
+    # bash
+    echo '[ -f /etc/bash_completion ] && source /etc/bash_completion' >> /etc/profile.d/load_completions.sh
+    echo '. /etc/profile' >> ~/.bashrc
+    echo '. /etc/profile' >> "/home/$TEST_USER/.bashrc"
+    if [ ! -e /etc/bash_completion ]; then
+        ln -sf /usr/share/bash-completion/bash_completion /etc/bash_completion
+    fi
+    
+    # zsh
+    set_zsh_defaults ~/.zshrc
+    set_zsh_defaults "/home/$TEST_USER/.zshrc"
+    
+    # set default shell to zsh
+    # echo "/usr/bin/zsh" >> /etc/shells
+    if command -V zsh >/dev/null 2>&1; then
+        chsh -s "$(which zsh)"
+    fi
+}
+
 main() {
     configure_users
+    configure_shells
     configure_services
     install_container_management
 }

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -7,7 +7,7 @@ ENV INSTALL="false"
 # ENV BOOTSTRAP="false"
 
 # Install
-RUN apt-get -y update \
+RUN apt-get -y update --allow-releaseinfo-change \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         wget \
         curl \
@@ -18,6 +18,11 @@ RUN apt-get -y update \
         systemd \
         systemd-sysv \
         ssh \
+        # shells
+        bash \
+        bash-completion \
+        zsh \
+        fish \
         collectd-core \
         # extra collectd shared libraries
         libmnl0 \

--- a/justfile
+++ b/justfile
@@ -85,12 +85,16 @@ down-all:
 bootstrap *ARGS:
     @docker compose --env-file {{DEV_ENV}} -f images/{{IMAGE}}/docker-compose.yaml exec tedge env C8Y_USER=${C8Y_USER:-} C8Y_PASSWORD=${C8Y_PASSWORD:-} DEVICE_ID=${DEVICE_ID:-} bootstrap.sh {{ARGS}}
 
+# Configure and register the device to the cloud using go-c8y- c8y-tedge extension
+bootstrap-c8y *ARGS:
+    cd "images/{{IMAGE}}" && c8y tedge bootstrap-container tedge {{ARGS}}
+
 # Bootstrap container using the go-c8y-cli c8y-tedge extension
 bootstrap-container *ARGS="":
     cd "images/{{IMAGE}}" && c8y tedge bootstrap-container bootstrap {{ARGS}}
 
 # Start a shell on the main device
-shell *args='bash':
+shell *args='zsh':
     docker compose -f images/{{IMAGE}}/docker-compose.yaml exec tedge {{args}}
 
 # Start a shell on the child device


### PR DESCRIPTION
Install and configure the following shells so that `tedge` tab completion works out of the box for the root and `iotadmin` user.

* bash
* zsh
* fish