### PR TITLE
fix: define a start command to avoid restarting the tedge-agent on a reconnect

### DIFF
--- a/images/common/config/system.toml
+++ b/images/common/config/system.toml
@@ -2,6 +2,7 @@
 [init]
 name = "systemd"
 is_available = ["/bin/systemctl", "--version"]
+start = ["/bin/systemctl", "start", "{}"]
 restart = ["/bin/systemctl", "restart", "{}"]
 stop =  ["/bin/systemctl", "stop", "{}"]
 enable =  ["/bin/systemctl", "enable", "{}"]


### PR DESCRIPTION
The thin-edge.io init system definition file (`system.toml`) did not have a "start" method defined, which led to the restart command being used by default.

Adding an explicit "start" command avoids unexpected restarts of teh tedge-agent when running `tedge reconnect c8y`.