### PR TITLE
feat: add locales to allow using utf-8 characters on the console

### DIFF
--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -3,6 +3,7 @@ FROM debian:12-slim
 # Install
 RUN apt-get -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        locales \
         wget \
         curl \
         gnupg2 \

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -64,6 +64,22 @@ zstyle ':completion:*' menu select
 # bind shift+tab to reverse menu complete
 zmodload zsh/complist
 bindkey -M menuselect '^[[Z' reverse-menu-complete
+
+# enable utf-8
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+export LANGUAGE=C.UTF-8
+EOT
+}
+
+set_bash_defaults() {
+    cat <<EOT
+. /etc/profile
+
+# enable utf-8
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+export LANGUAGE=C.UTF-8
 EOT
 }
 
@@ -72,8 +88,9 @@ configure_shells() {
 
     # bash
     echo '[ -f /etc/bash_completion ] && source /etc/bash_completion' >> /etc/profile.d/load_completions.sh
-    echo '. /etc/profile' >> ~/.bashrc
-    echo '. /etc/profile' >> "/home/$TEST_USER/.bashrc"
+    set_bash_defaults >> ~/.bashrc
+    set_bash_defaults >> "/home/$TEST_USER/.bashrc"
+
     if [ ! -e /etc/bash_completion ]; then
         ln -sf /usr/share/bash-completion/bash_completion /etc/bash_completion
     fi

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -9,6 +9,7 @@ ENV INSTALL="false"
 # Install
 RUN apt-get -y update --allow-releaseinfo-change \
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        locales \
         wget \
         curl \
         gnupg2 \


### PR DESCRIPTION
Install the locales package and set the appropriate encoding variables for both bash and zsh to allow users to use utf-8 characters on the console (provided their terminal also supports it!).

This is required in order to publish units (which is included in the next thin-edge.io release, 1.7.x) which often use extended characters:

```sh
tedge mqtt pub -r 'te/device/main///m/battery_reading/meta' '{
  "temperature": {
    "unit": "°C",
    "precision": "±0.1°C"
  },
  "voltage": {
    "unit": "V",
    "min": 0,
    "max": 20
  },
  "current": {
    "unit": "A"
  }
}'
```