### PR TITLE
fix(systemd): preserve original tedge sudoers rules

### DIFF
--- a/images/common/config/sudoers.d/tedge
+++ b/images/common/config/sudoers.d/tedge
@@ -1,1 +1,0 @@
-tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/tedge-write /etc/*, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /bin/systemctl, /bin/journalctl, /usr/bin/on_shutdown.sh

--- a/images/common/config/sudoers.d/tedge-system
+++ b/images/common/config/sudoers.d/tedge-system
@@ -1,0 +1,1 @@
+tedge  ALL = (ALL) NOPASSWD:SETENV: /sbin/shutdown, /bin/systemctl, /bin/journalctl, /usr/bin/on_shutdown.sh


### PR DESCRIPTION
Only add additional sudoer rules in a new file rather than overriding the defaults installed with tedge.

This allows more seemless upgrade when new rules are added in the tedge package.