### PR TITLE
refactor: move c8y specific settings to c8y/mapper.toml

### DIFF
--- a/images/common/config/tedge.toml
+++ b/images/common/config/tedge.toml
@@ -7,10 +7,6 @@ client.host = "tedge"
 bind.address = "0.0.0.0"
 client.host = "tedge"
 
-[c8y]
-proxy.bind.address = "0.0.0.0"
-proxy.client.host = "tedge"
-
 [software.plugin]
 # Exclude uninteresting software management packages (regardless of type)
 exclude = "^(glibc|lib|kernel-|iptables-module).*"

--- a/images/common/mappers/c8y/mapper.toml
+++ b/images/common/mappers/c8y/mapper.toml
@@ -1,0 +1,5 @@
+cloud_type = "c8y"
+
+[proxy]
+bind.address = "0.0.0.0"
+client.host = "tedge"

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -119,6 +119,7 @@ COPY common/config/tedge-container-plugin.env /etc/tedge-container-plugin/env
 
 COPY common/config/system.toml /etc/tedge/
 COPY common/config/tedge.toml /etc/tedge/
+COPY common/mappers /etc/tedge/
 COPY common/config/tedge-configuration-plugin.toml /etc/tedge/plugins/
 COPY common/config/tedge-log-plugin.toml /etc/tedge/plugins/
 COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/


### PR DESCRIPTION
Move the c8y specific logic out of the tedge.toml and to the newer `mapers/c8y/mapper.toml` file.