### PR TITLE
feat: update base image to debian 13 (trixie)

### DIFF
--- a/images/child-device-systemd/child.dockerfile
+++ b/images/child-device-systemd/child.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:13-slim
 
 # Install
 RUN apt-get -y update \

--- a/images/common/config/tedge.toml
+++ b/images/common/config/tedge.toml
@@ -1,3 +1,6 @@
+[config]
+version = "2"
+
 [mqtt]
 bind.address = "0.0.0.0"
 bind.port = 1883

--- a/images/common/mappers/c8y/mapper.toml
+++ b/images/common/mappers/c8y/mapper.toml
@@ -1,5 +1,7 @@
 cloud_type = "c8y"
 
-[proxy]
-bind.address = "0.0.0.0"
-client.host = "tedge"
+[proxy.bind]
+address = "0.0.0.0"
+
+[proxy.client]
+host = "tedge"

--- a/images/common/optional-installer.sh
+++ b/images/common/optional-installer.sh
@@ -22,6 +22,10 @@ install_container_management () {
     # Source: podman-docker debian package
     echo 'L+  %t/docker.sock   -    -    -     -   %t/podman/podman.sock' | tee /usr/lib/tmpfiles.d/podman-docker-socket.conf
     systemd-tmpfiles --create podman-docker.conf >/dev/null || true
+
+    # enable the service by default instead of using a socket activated service
+    # so it is can be auto detected by tedge-container-plugin
+    sudo systemctl enable podman.service
 }
 
 configure_users() {

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -119,7 +119,7 @@ COPY common/config/tedge-container-plugin.env /etc/tedge-container-plugin/env
 
 COPY common/config/system.toml /etc/tedge/
 COPY common/config/tedge.toml /etc/tedge/
-COPY common/mappers /etc/tedge/
+COPY common/mappers /etc/tedge/mappers/
 COPY common/config/tedge-configuration-plugin.toml /etc/tedge/plugins/
 COPY common/config/tedge-log-plugin.toml /etc/tedge/plugins/
 COPY common/utils/workflows/firmware_update.toml /etc/tedge/operations/

--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:13-slim
 
 ARG VERSION=
 ARG TEDGE_CHANNEL=release


### PR DESCRIPTION
Use debian 13 (trixie) so that newer versions of packages can be used, e.g. podman/podman-compose which fixes long standing bugs

**Note**

This PR is on hold until a mosquitto version that doesn't drop messages when using the per_listener setting is available for Debian 13 (trixie). The default mosqutito version 2.0.21-1 is not suitable.