### PR TITLE
fix: replace tedge-nodered-plugin-ng with tedge-nodered-plugin

### DIFF
--- a/images/debian-systemd/debian-systemd.dockerfile
+++ b/images/debian-systemd/debian-systemd.dockerfile
@@ -86,7 +86,7 @@ RUN echo "running" \
         tedge-inventory-plugin \
         tedge-command-plugin \
         tedge-monit-setup \
-        tedge-nodered-plugin-ng \
+        tedge-nodered-plugin \
         # Local PKI service for easy child device registration
         tedge-pki-smallstep-ca \
     && systemctl disable c8y-firmware-plugin.service \


### PR DESCRIPTION
Use the official `tedge-nodered-plugin` package instead of `tedge-nodered-plugin`.